### PR TITLE
Refactor dependencies in pyproject.toml to remove version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,19 @@ description = "tvkit is a Python library that fetches real-time stock data from 
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pydantic>=2.11.7",
-    "ruff>=0.12.4",
-    "pytest>=8.0.0",
-    "pytest-asyncio>=0.23.0",
-    "websockets>=13.0",
-    "httpx>=0.28.0",
-    "polars>=1.0.0",
-    "pandas>=2.3.1",
-    "pyarrow>=21.0.0",
-    "matplotlib>=3.10.3",
-    "seaborn>=0.13.2",
-    "build>=1.2.2.post1",
-    "twine>=6.1.0",
+    "pydantic",
+    "ruff",
+    "pytest",
+    "pytest-asyncio",
+    "websockets",
+    "httpx",
+    "polars",
+    "pandas",
+    "pyarrow",
+    "matplotlib",
+    "seaborn",
+    "build",
+    "twine",
 ]
 authors = [{ name = "lumduan", email = "b@candythink.com" }]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.3"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"
+authors = [{ name = "lumduan", email = "b@candythink.com" }]
+license = { file = "LICENSE" }
 dependencies = [
     "pydantic>=2.0.0",
     "websockets>=11.0.0",
@@ -24,8 +26,6 @@ dev = [
     "twine>=4.0.0",
     "mypy>=1.17.0"
 ]
-authors = [{ name = "lumduan", email = "b@candythink.com" }]
-license = { file = "LICENSE" }
 keywords = ["tradingview", "stock", "trading", "finance", "api", "market-data"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,19 @@ description = "tvkit is a Python library that fetches real-time stock data from 
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "lumduan", email = "b@candythink.com" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
+keywords = ["tradingview", "stock", "trading", "finance", "api", "market-data"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Office/Business :: Financial",
+]
 dependencies = [
     "pydantic>=2.0.0",
     "websockets>=11.0.0",
@@ -25,18 +37,6 @@ dev = [
     "build>=1.0.0",
     "twine>=4.0.0",
     "mypy>=1.17.0"
-]
-keywords = ["tradingview", "stock", "trading", "finance", "api", "market-data"]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Office/Business :: Financial",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,24 @@ description = "tvkit is a Python library that fetches real-time stock data from 
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pydantic",
-    "ruff",
-    "pytest",
-    "pytest-asyncio",
-    "websockets",
-    "httpx",
-    "polars",
-    "pandas",
-    "pyarrow",
-    "matplotlib",
-    "seaborn",
-    "build",
-    "twine",
+    "pydantic>=2.0.0",
+    "websockets>=11.0.0",
+    "httpx>=0.24.0",
+    "polars>=0.19.0",
+    "pandas>=2.0.0",
+    "pyarrow>=12.0.0",
+    "matplotlib>=3.7.0",
+    "seaborn>=0.12.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.12.4",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "build>=1.0.0",
+    "twine>=4.0.0",
+    "mypy>=1.17.0"
 ]
 authors = [{ name = "lumduan", email = "b@candythink.com" }]
 license = { file = "LICENSE" }
@@ -50,6 +55,3 @@ exclude = ["debug*", "tests*", "scripts*", "docs*"]
 
 [tool.setuptools.package-data]
 tvkit = ["py.typed"]
-
-[dependency-groups]
-dev = ["mypy>=1.17.0"]


### PR DESCRIPTION
The defined version requirements in the `toml` file is causing dependency version conflicts with other packages in a project repo. This issue is similar to the prior PR, where the bleeding-edge versions of packages cause problems for other users. I have removed the defined versions, so `pip` can resolve the version requirement now.