### PR TITLE
feat(validation): data integrity validation layer v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] — 2026-04-09
+
+### Added
+
+- **`tvkit.validation` module** — data integrity validation layer for OHLCV Polars DataFrames:
+  - `validate_ohlcv(df, *, interval, checks)` — composite validator; runs all applicable checks
+    in deterministic order and returns a structured `ValidationResult`
+  - `ValidationResult` — Pydantic model with `is_valid`, `violations`, `bars_checked`,
+    `checks_run` fields; `.errors` and `.warnings` convenience properties
+  - `Violation` — typed Pydantic model per violation: `check`, `severity`, `message`,
+    `affected_rows`, `context`
+  - `ViolationType` — `StrEnum` for all check types: `DUPLICATE_TIMESTAMP`,
+    `NON_MONOTONIC_TIMESTAMP`, `OHLC_INCONSISTENCY`, `NEGATIVE_VOLUME`, `GAP_DETECTED`
+  - `DataIntegrityError` — public exception raised by `DataExporter` in strict mode;
+    carries the full `ValidationResult` at `.result`
+  - `ContextValue`, `ViolationContext` — type aliases for structured violation context dicts
+- **Five built-in OHLCV checks** (all pure functions; `list[Violation]` return type):
+  - `check_duplicate_timestamps(df)` — detects bars sharing a timestamp (ERROR)
+  - `check_monotonic_timestamps(df)` — detects out-of-order timestamp pairs (ERROR)
+  - `check_ohlc_consistency(df)` — detects `low > open/close`, `open/close > high`, and NaN in
+    price columns (ERROR)
+  - `check_volume_non_negative(df)` — detects `volume < 0` or NaN volume (ERROR)
+  - `check_gaps(df, interval)` — detects timestamp gaps larger than the expected interval cadence
+    (WARNING); raises `ValueError` when called without a valid `interval`
+- **`DataExporter` validation integration** — `to_csv()` and `to_json()` now accept three
+  keyword-only parameters:
+  - `validate: bool = False` — when `True`, runs `validate_ohlcv()` before exporting and logs
+    each violation at `WARNING` level; export always proceeds in this mode
+  - `strict: bool = False` — when `True` alongside `validate=True`, raises `DataIntegrityError`
+    on ERROR violations and does not write the output file; WARNING-only results never raise
+  - `interval: str | None = None` — passed through to `validate_ohlcv()` for gap detection
+
+### Notes
+
+- Gap detection in Phase 1 is cadence-only (not calendar-aware). For daily equity bars (`"1D"`),
+  weekends and public holidays are reported as `GAP_DETECTED` WARNING violations. This is
+  intentional: WARNING violations do not affect `is_valid` and do not block exports. Calendar-aware
+  gap detection is planned as a future enhancement.
+- Validation is non-destructive — it never mutates the DataFrame. Check functions are pure with
+  zero side effects.
+- Scanner data passed to `DataExporter` silently skips validation (only `list[OHLCVBar]` input
+  triggers the validation path).
+
 ## [0.8.0] — 2026-04-08
 
 ### Added

--- a/docs/concepts/data-integrity.md
+++ b/docs/concepts/data-integrity.md
@@ -1,0 +1,146 @@
+# Data Integrity for OHLCV Data
+
+[Home](../index.md) > Concepts > Data Integrity
+
+This page explains why OHLCV data integrity matters, what failure modes occur in practice, and how `tvkit.validation` is designed to address them.
+
+---
+
+## The Problem
+
+tvkit retrieves OHLCV data over TradingView's WebSocket API — a persistent, real-time connection that delivers bars as they are produced by the exchange. This delivery mechanism introduces failure modes that are not present in static file-based data sources:
+
+| Failure Mode | How It Happens |
+|---|---|
+| **Duplicate bars** | WebSocket reconnects replay bars already received — the same timestamp appears more than once |
+| **Out-of-order timestamps** | Late-arriving or reordered messages cause bars to appear non-chronologically |
+| **OHLC constraint violations** | Encoding bugs or gap-fill edge cases produce bars where `low > open`, `open > high`, or similar |
+| **Negative or NaN volume** | Edge cases in the TradingView data protocol produce invalid volume values |
+| **Unexpected gaps** | Connection loss or exchange interruptions leave missing bars for a given interval |
+
+Without a validation layer, these issues are silently passed to downstream pipelines — corrupting exports, breaking backtests, and introducing subtle, hard-to-debug data quality bugs.
+
+---
+
+## Why Silent Corruption Is Dangerous
+
+The failure modes above do not produce exceptions. A DataFrame with a duplicate timestamp row, an OHLC inversion, or a missing bar looks structurally identical to clean data. Downstream code — whether a moving average calculation, a backtest, or a CSV export — will consume corrupt data without any indication of a problem.
+
+The resulting bugs surface far from the data source:
+- A backtest gives different results on different days because cached bars contain duplicates that change which rows are processed
+- A strategy fires spurious signals because OHLC constraints are violated on specific bars
+- Aggregated statistics are subtly wrong because gaps in the data are not accounted for
+
+Validation at the boundary — before the data enters any pipeline — is the only reliable defense.
+
+---
+
+## tvkit.validation Design Philosophy
+
+`tvkit.validation` is built around six principles:
+
+| Principle | Decision |
+|---|---|
+| **Non-destructive** | Validation reports problems but never mutates the DataFrame. The caller decides what to do. |
+| **Composable** | Individual checks are independently callable — use only what you need. |
+| **Structured results** | All violations are typed Pydantic models, not raw strings or log messages. |
+| **Pure functions** | Check functions have zero side effects — no logging, no I/O, no mutation. |
+| **Explicit errors** | Missing required arguments raise `ValueError` immediately, not silently skipped. |
+| **Deterministic** | Checks run in a fixed order. Violations are sorted by check order, then row index. The same DataFrame always produces the same result. |
+
+---
+
+## Severity Levels
+
+Not all violations are equally serious. `tvkit.validation` uses two severity levels:
+
+### ERROR
+
+Structural data corruption. The data cannot be safely used by downstream pipelines.
+
+`ValidationResult.is_valid` is `False` when any ERROR violation is present.
+
+| Check | What it catches |
+|---|---|
+| `DUPLICATE_TIMESTAMP` | Two or more bars share the same timestamp |
+| `NON_MONOTONIC_TIMESTAMP` | Timestamps are not strictly increasing |
+| `OHLC_INCONSISTENCY` | `low > open`, `low > close`, `open > high`, `close > high`, or NaN in any price column |
+| `NEGATIVE_VOLUME` | `volume < 0` or NaN volume |
+
+### WARNING
+
+Potentially expected conditions that the caller should acknowledge. `ValidationResult.is_valid` stays `True` even when WARNING violations exist.
+
+| Check | What it catches |
+|---|---|
+| `GAP_DETECTED` | Consecutive bars with a timestamp gap larger than the expected interval |
+
+WARNING-only results do not block `DataExporter` even with `strict=True`. The caller is responsible for deciding whether gaps are acceptable.
+
+---
+
+## The Gap Detection Limitation (Phase 1)
+
+Gap detection in Phase 1 is **cadence-only and not calendar-aware**.
+
+For a given interval, the check flags any consecutive pair of bars where the timestamp difference exceeds one expected interval period. This works correctly for:
+
+- **Continuous markets** — crypto, forex: bars are produced 24/7, so any gap is unexpected
+- **Intraday bars** — `"1H"`, `"15"` within a single trading session
+
+For **daily equity bars** (`"1D"`), however, the market does not trade every calendar day. Weekends, public holidays, and exchange-specific non-trading days all produce gaps in the bar sequence that are completely expected. Phase 1 reports these as `GAP_DETECTED` WARNING violations.
+
+**This is intentional.** The WARNING severity means `is_valid` stays `True` and exports are not blocked. Calendar-aware gap detection (which would suppress expected non-trading-day gaps) is planned as a future enhancement.
+
+To suppress gap warnings for equity daily data, either omit `interval` or run checks selectively:
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+# Option 1: omit interval (gap detection silently skipped)
+result = validate_ohlcv(df)
+
+# Option 2: run all structural checks explicitly, excluding GAP_DETECTED
+result = validate_ohlcv(
+    df,
+    checks=[
+        ViolationType.DUPLICATE_TIMESTAMP,
+        ViolationType.NON_MONOTONIC_TIMESTAMP,
+        ViolationType.OHLC_INCONSISTENCY,
+        ViolationType.NEGATIVE_VOLUME,
+    ],
+)
+```
+
+---
+
+## Validation at the Export Boundary
+
+The primary integration point is `DataExporter`. Validation is opt-in and non-breaking:
+
+```python
+from tvkit.export import DataExporter
+from tvkit.validation import DataIntegrityError
+
+exporter = DataExporter()
+
+# validate=True: violations are logged at WARNING, export always proceeds
+await exporter.to_csv(bars, "output.csv", validate=True, interval="1D")
+
+# strict=True: DataIntegrityError raised on ERROR violations, file is NOT written
+try:
+    await exporter.to_csv(bars, "output.csv", validate=True, strict=True, interval="1D")
+except DataIntegrityError as e:
+    for v in e.result.errors:
+        logger.error(v.message, extra={"check": v.check.value, "rows": v.affected_rows})
+```
+
+`DataIntegrityError.result` carries the full `ValidationResult`, so structured error handling and retry logic have access to every violation detail.
+
+---
+
+## Further Reading
+
+- [Data Validation guide](../guides/data-validation.md) — workflow examples and common patterns
+- [`validate_ohlcv` reference](../reference/validation/validate_ohlcv.md) — full function signature and schema contract
+- [Validation models reference](../reference/validation/models.md) — `ValidationResult`, `Violation`, `ViolationType`, `DataIntegrityError`

--- a/docs/guides/data-validation.md
+++ b/docs/guides/data-validation.md
@@ -1,0 +1,212 @@
+# Data Validation
+
+[Home](../index.md) > Guides > Data Validation
+
+`tvkit.validation` provides a data integrity layer for OHLCV data. It catches issues that TradingView's WebSocket API can introduce — duplicate bars, out-of-order timestamps, OHLC constraint violations, negative volume, and unexpected gaps — before they silently corrupt exports, backtests, or downstream pipelines.
+
+## Prerequisites
+
+- tvkit installed: see [Installation](../getting-started/installation.md)
+- Fetch OHLCV data first: see [Historical Data guide](historical-data.md)
+
+---
+
+## Validation in One Line
+
+The simplest usage is validating a DataFrame you already have:
+
+```python
+import polars as pl
+from tvkit.validation import validate_ohlcv
+
+result = validate_ohlcv(df)
+
+if result.is_valid:
+    print(f"Clean: {result.bars_checked} bars, no errors")
+else:
+    for v in result.errors:
+        print(f"[{v.check}] {v.message} (rows: {v.affected_rows})")
+```
+
+---
+
+## Validation Before Export
+
+The most common pattern is gating an export on validation. Pass `validate=True` to `to_csv()` or `to_json()`:
+
+```python
+import asyncio
+from tvkit.api.chart.ohlcv import OHLCV
+from tvkit.export import DataExporter
+
+async def main() -> None:
+    async with OHLCV() as client:
+        bars = await client.get_historical_ohlcv("NASDAQ:AAPL", interval="1D", bars_count=365)
+
+    exporter = DataExporter()
+
+    # Logging mode: violations are logged at WARNING, export always proceeds
+    await exporter.to_csv(bars, "aapl.csv", validate=True, interval="1D")
+
+asyncio.run(main())
+```
+
+When violations are found, each one is logged at `WARNING` level with structured fields:
+
+```
+WARNING  tvkit.export.data_exporter: duplicate timestamp at 2023-06-01T00:00:00
+         extra={"check": "duplicate_timestamp", "rows": [42, 43]}
+```
+
+---
+
+## Strict Mode — Block Exports on Corrupt Data
+
+Use `strict=True` to treat ERROR violations as a hard failure. The file is **not** written:
+
+```python
+from tvkit.validation import DataIntegrityError
+
+try:
+    await exporter.to_csv(bars, "aapl.csv", validate=True, strict=True, interval="1D")
+except DataIntegrityError as e:
+    print(f"Export blocked: {len(e.result.errors)} error(s) found")
+    for v in e.result.errors:
+        print(f"  [{v.check}] {v.message} (rows {v.affected_rows})")
+```
+
+`DataIntegrityError.result` is the full `ValidationResult` — use it for structured logging or retry logic.
+
+---
+
+## Severity Levels
+
+| Severity | `is_valid` | Blocks export (`strict=True`) | When |
+|----------|-----------|-------------------------------|------|
+| `ERROR` | `False` | Yes | Structural corruption (duplicate bars, OHLC violations, etc.) |
+| `WARNING` | `True` | **No** | Expected conditions (calendar gaps in daily equity data) |
+
+WARNING-only results never raise even with `strict=True`:
+
+```python
+# Daily equity data will have weekend gaps → GAP_DETECTED WARNING
+# strict=True still does NOT block this export
+await exporter.to_csv(
+    equity_bars, "spy.csv", validate=True, strict=True, interval="1D"
+)
+```
+
+---
+
+## Gap Detection
+
+Gap detection requires an explicit `interval`. Without it, `GAP_DETECTED` checks are silently skipped:
+
+```python
+# No gap check (interval omitted)
+result = validate_ohlcv(df)
+
+# Gap check enabled
+result = validate_ohlcv(df, interval="1D")
+result = validate_ohlcv(df, interval="1H")
+result = validate_ohlcv(df, interval="15")   # 15-minute bars
+```
+
+### Calendar Gap Limitation
+
+Phase 1 gap detection is **cadence-only** — it flags any pair of consecutive bars where the timestamp difference exceeds one expected interval period. For daily equity bars (`"1D"`):
+
+- Weekends → flagged as `GAP_DETECTED` (WARNING)
+- Public holidays → flagged as `GAP_DETECTED` (WARNING)
+- Exchange-specific non-trading days → flagged as `GAP_DETECTED` (WARNING)
+
+This is **intentional**. For continuous markets (crypto, forex) and intraday bars, gap detection works without noise. Calendar-aware gap detection is planned as a future enhancement.
+
+To suppress calendar gap noise for equity data, validate without gap detection:
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+# Run all checks except gap detection
+result = validate_ohlcv(
+    df,
+    checks=[
+        ViolationType.DUPLICATE_TIMESTAMP,
+        ViolationType.NON_MONOTONIC_TIMESTAMP,
+        ViolationType.OHLC_INCONSISTENCY,
+        ViolationType.NEGATIVE_VOLUME,
+    ],
+)
+```
+
+---
+
+## Standalone Validation Without Export
+
+`validate_ohlcv()` is a pure function — it does not write files or log. Use it anywhere in your pipeline:
+
+```python
+from tvkit.validation import validate_ohlcv, ValidationResult, ViolationType
+
+# After fetching, before caching
+df = await exporter.to_polars(bars)
+result: ValidationResult = validate_ohlcv(df, interval="1D")
+
+# Log structured violations
+for v in result.violations:
+    if v.severity == "ERROR":
+        logger.error(
+            v.message,
+            extra={"check": v.check.value, "rows": v.affected_rows, **v.context},
+        )
+    else:
+        logger.warning(
+            v.message,
+            extra={"check": v.check.value, "rows": v.affected_rows},
+        )
+
+# Raise programmatically
+if not result.is_valid:
+    raise ValueError(f"Data integrity failed: {len(result.errors)} error(s)")
+```
+
+---
+
+## Selective Checks
+
+Run a specific subset of checks:
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+# Only check for structural issues (fastest path)
+result = validate_ohlcv(df, checks=[ViolationType.DUPLICATE_TIMESTAMP])
+
+# Only check OHLC consistency and volume
+result = validate_ohlcv(
+    df,
+    checks=[ViolationType.OHLC_INCONSISTENCY, ViolationType.NEGATIVE_VOLUME],
+)
+```
+
+Checks always execute in the deterministic order (`DUPLICATE_TIMESTAMP` → `NON_MONOTONIC_TIMESTAMP` → `OHLC_INCONSISTENCY` → `NEGATIVE_VOLUME` → `GAP_DETECTED`) regardless of the order in the `checks` list.
+
+---
+
+## What Each Check Detects
+
+| Check | What it catches | Severity |
+|-------|----------------|----------|
+| `DUPLICATE_TIMESTAMP` | Two or more bars with the same timestamp (e.g., reconnect replay) | ERROR |
+| `NON_MONOTONIC_TIMESTAMP` | Timestamps not strictly increasing (e.g., late-arriving or reordered bars) | ERROR |
+| `OHLC_INCONSISTENCY` | `low > open`, `low > close`, `open > high`, `close > high`, or NaN in any price column | ERROR |
+| `NEGATIVE_VOLUME` | `volume < 0` or NaN volume | ERROR |
+| `GAP_DETECTED` | Timestamp gap larger than the expected interval cadence | WARNING |
+
+---
+
+## Full API Reference
+
+- [`validate_ohlcv()` — function reference](../reference/validation/index.md)
+- [Data models: `ValidationResult`, `Violation`, `ViolationType`, `DataIntegrityError`](../reference/validation/models.md)
+- [`DataExporter.to_csv()` / `.to_json()` — updated params](../reference/export/exporter.md)

--- a/docs/reference/export/exporter.md
+++ b/docs/reference/export/exporter.md
@@ -224,6 +224,10 @@ async def to_json(
     data: list[OHLCVBar] | list[StockData],
     file_path: Path | str,
     include_metadata: bool = True,
+    *,
+    validate: bool = False,
+    strict: bool = False,
+    interval: str | None = None,
     **json_options: Any,
 ) -> Path: ...
 ```
@@ -235,6 +239,9 @@ async def to_json(
 | `data` | `list[OHLCVBar] \| list[StockData]` | required | Data to export |
 | `file_path` | `Path \| str` | required | Output JSON file path |
 | `include_metadata` | `bool` | `True` | Embed export metadata in the JSON output |
+| `validate` | `bool` | `False` | If `True`, run `validate_ohlcv()` before writing. Violations are logged at `WARNING` level. Only applies to OHLCV data; scanner data silently skips validation. |
+| `strict` | `bool` | `False` | If `True` and `validate=True`, raise `DataIntegrityError` on ERROR violations. The file is **not** written. WARNING-only results do not raise. |
+| `interval` | `str \| None` | `None` | Passed to `validate_ohlcv()` for gap detection. Only relevant when `validate=True`. |
 | `**json_options` | `Any` | — | Additional options passed to the JSON formatter (e.g., `indent=4`) |
 
 #### Returns
@@ -245,6 +252,7 @@ async def to_json(
 
 | Exception | When |
 |-----------|------|
+| `DataIntegrityError` | `validate=True`, `strict=True`, and ERROR violations found |
 | `RuntimeError` | Export failed or formatter did not produce a file |
 
 #### Example
@@ -255,6 +263,11 @@ from tvkit.export import DataExporter
 exporter = DataExporter()
 path = await exporter.to_json(bars, "aapl.json", indent=2)
 print(path)  # PosixPath('aapl.json')
+
+# With validation
+path = await exporter.to_json(
+    bars, "aapl.json", validate=True, strict=True, interval="1D"
+)
 ```
 
 ---
@@ -269,6 +282,10 @@ async def to_csv(
     data: list[OHLCVBar] | list[StockData],
     file_path: Path | str,
     include_metadata: bool = True,
+    *,
+    validate: bool = False,
+    strict: bool = False,
+    interval: str | None = None,
     **csv_options: Any,
 ) -> Path: ...
 ```
@@ -280,6 +297,9 @@ async def to_csv(
 | `data` | `list[OHLCVBar] \| list[StockData]` | required | Data to export |
 | `file_path` | `Path \| str` | required | Output CSV file path |
 | `include_metadata` | `bool` | `True` | Write a `<filename>.metadata.txt` sidecar file alongside the CSV |
+| `validate` | `bool` | `False` | If `True`, run `validate_ohlcv()` before writing. Violations are logged at `WARNING` level. Only applies to OHLCV data; scanner data silently skips validation. |
+| `strict` | `bool` | `False` | If `True` and `validate=True`, raise `DataIntegrityError` on ERROR violations. The file is **not** written. WARNING-only results do not raise. |
+| `interval` | `str \| None` | `None` | Passed to `validate_ohlcv()` for gap detection. Only relevant when `validate=True`. |
 | `**csv_options` | `Any` | — | Additional options passed to the CSV formatter (e.g., `delimiter=";"`, `timestamp_format="iso"`) |
 
 #### Returns
@@ -290,6 +310,7 @@ async def to_csv(
 
 | Exception | When |
 |-----------|------|
+| `DataIntegrityError` | `validate=True`, `strict=True`, and ERROR violations found |
 | `RuntimeError` | Export failed or formatter did not produce a file |
 
 #### Example
@@ -300,6 +321,11 @@ from tvkit.export import DataExporter
 exporter = DataExporter()
 path = await exporter.to_csv(bars, "aapl.csv", timestamp_format="iso")
 # Writes: aapl.csv and aapl.csv.metadata.txt
+
+# With validation
+path = await exporter.to_csv(
+    bars, "aapl.csv", validate=True, strict=True, interval="1D"
+)
 ```
 
 ---

--- a/docs/reference/validation/index.md
+++ b/docs/reference/validation/index.md
@@ -1,0 +1,180 @@
+# validate_ohlcv Reference
+
+**Module:** `tvkit.validation`
+**Introduced in:** v0.9.0
+
+Validates the structural and logical integrity of an OHLCV Polars DataFrame. Returns a structured `ValidationResult` describing any violations found. All checks are pure functions with no side effects.
+
+## Quick Example
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+result = validate_ohlcv(df, interval="1D")
+
+if result.is_valid:
+    await exporter.to_csv(bars, "output.csv")
+else:
+    for v in result.errors:
+        logger.error(v.message, extra={"check": v.check, "rows": v.affected_rows})
+```
+
+---
+
+## Import
+
+```python
+from tvkit.validation import (
+    validate_ohlcv,
+    ValidationResult,
+    Violation,
+    ViolationType,
+    DataIntegrityError,
+    ContextValue,
+    ViolationContext,
+)
+```
+
+---
+
+## `validate_ohlcv()`
+
+```python
+def validate_ohlcv(
+    df: pl.DataFrame,
+    *,
+    interval: str | None = None,
+    checks: list[ViolationType] | None = None,
+) -> ValidationResult:
+```
+
+Validates the integrity of an OHLCV Polars DataFrame.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `df` | `pl.DataFrame` | — | DataFrame with required columns: `timestamp`, `open`, `high`, `low`, `close`, `volume` |
+| `interval` | `str \| None` | `None` | Interval string for gap detection (e.g. `"1D"`, `"1H"`, `"15"`). Required for `GAP_DETECTED` check. Silently skips gap detection if `None` and `GAP_DETECTED` is not in `checks`. |
+| `checks` | `list[ViolationType] \| None` | `None` | Subset of checks to run. If `None`, all applicable checks run. Execution always follows deterministic order regardless of list order. |
+
+### Returns
+
+`ValidationResult` — see [models reference](models.md).
+
+### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `ValueError` | Required column missing or unsupported dtype |
+| `ValueError` | `ViolationType.GAP_DETECTED` in `checks` but `interval` is `None` |
+| `ValueError` | Unknown value in `checks` |
+
+---
+
+## Required Schema
+
+`validate_ohlcv()` raises `ValueError` if the DataFrame does not meet the schema before any check runs.
+
+| Column | Accepted Polars Dtypes | Nullable |
+|--------|------------------------|----------|
+| `timestamp` | `Float64`, `Int64`, `Datetime(...)`, `Date` | No |
+| `open` | `Float64`, `Float32` | No |
+| `high` | `Float64`, `Float32` | No |
+| `low` | `Float64`, `Float32` | No |
+| `close` | `Float64`, `Float32` | No |
+| `volume` | `Float64`, `Float32`, `Int64` | No |
+
+**`Float64` timestamp note:** tvkit's `PolarsFormatter` produces `Float64` epoch-seconds timestamps. This is the canonical timestamp format for tvkit DataFrames.
+
+**`Int64` timestamp note:** Interpreted as epoch milliseconds (Polars convention). No conversion is performed — the caller is responsible for correct units.
+
+Empty DataFrames (0 rows) pass schema validation. All checks return empty violation lists.
+
+---
+
+## Deterministic Check Order
+
+When `checks=None`, all applicable checks run in this fixed order:
+
+| # | `ViolationType` | Severity | Condition |
+|---|-----------------|----------|-----------|
+| 1 | `DUPLICATE_TIMESTAMP` | ERROR | Any timestamp appears more than once |
+| 2 | `NON_MONOTONIC_TIMESTAMP` | ERROR | Any consecutive pair where `ts[i] >= ts[i+1]` |
+| 3 | `OHLC_INCONSISTENCY` | ERROR | Any bar where `low > open`, `low > close`, `open > high`, or `close > high`, or any NaN in OHLC columns |
+| 4 | `NEGATIVE_VOLUME` | ERROR | Any bar with `volume < 0` or NaN volume |
+| 5 | `GAP_DETECTED` | WARNING | Any consecutive pair where timestamp difference exceeds the expected interval |
+
+Violations are sorted by this check order, then by row index within each check. This ordering is stable across releases.
+
+---
+
+## Gap Detection Behavior
+
+| `interval` | `checks` | Behavior |
+|---|---|---|
+| `None` | `None` (all checks) | Gap detection silently skipped |
+| `"1D"` | `None` (all checks) | Gap detection runs |
+| `None` | `[ViolationType.GAP_DETECTED]` | Raises `ValueError` immediately |
+| `"1H"` | `[ViolationType.GAP_DETECTED]` | Gap detection runs |
+
+### Supported Interval Strings
+
+| String | Duration |
+|--------|----------|
+| `"1"` | 1 minute |
+| `"5"` | 5 minutes |
+| `"15"` | 15 minutes |
+| `"30"` | 30 minutes |
+| `"60"` / `"1H"` | 1 hour |
+| `"240"` / `"4H"` | 4 hours |
+| `"1D"` | 1 day |
+| `"1W"` | 1 week |
+| `"1M"` | 1 month (30 days) |
+
+### Phase 1 Calendar Limitation
+
+Gap detection in Phase 1 is **cadence-only and not calendar-aware**. For daily equity bars (`"1D"`), weekends and public holidays appear as `GAP_DETECTED` WARNING violations. These are expected and should be filtered by the caller if needed. Calendar-aware gap detection is planned as a future enhancement.
+
+---
+
+## Selective Checks
+
+Run only a specific subset of checks:
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+# Only check for duplicates and OHLC inconsistencies
+result = validate_ohlcv(
+    df,
+    checks=[ViolationType.DUPLICATE_TIMESTAMP, ViolationType.OHLC_INCONSISTENCY],
+)
+
+# Only gap detection (interval required)
+result = validate_ohlcv(
+    df,
+    interval="1H",
+    checks=[ViolationType.GAP_DETECTED],
+)
+```
+
+Checks always execute in `_CHECK_ORDER` regardless of the order in the `checks` list.
+
+---
+
+## DataExporter Integration
+
+`DataExporter.to_csv()` and `DataExporter.to_json()` accept opt-in validation via keyword-only parameters:
+
+```python
+exporter = DataExporter()
+
+# Logging mode: violations logged at WARNING, export always proceeds
+await exporter.to_csv(bars, "output.csv", validate=True, interval="1D")
+
+# Strict mode: DataIntegrityError raised on ERROR violations, file not written
+await exporter.to_csv(bars, "output.csv", validate=True, strict=True, interval="1D")
+```
+
+See [DataExporter reference](../export/exporter.md) and the [data validation guide](../../guides/data-validation.md) for full details.

--- a/docs/reference/validation/index.md
+++ b/docs/reference/validation/index.md
@@ -1,27 +1,22 @@
-# validate_ohlcv Reference
+# Validation Reference
 
 **Module:** `tvkit.validation`
 **Introduced in:** v0.9.0
 
-Validates the structural and logical integrity of an OHLCV Polars DataFrame. Returns a structured `ValidationResult` describing any violations found. All checks are pure functions with no side effects.
-
-## Quick Example
-
-```python
-from tvkit.validation import validate_ohlcv, ViolationType
-
-result = validate_ohlcv(df, interval="1D")
-
-if result.is_valid:
-    await exporter.to_csv(bars, "output.csv")
-else:
-    for v in result.errors:
-        logger.error(v.message, extra={"check": v.check, "rows": v.affected_rows})
-```
+`tvkit.validation` provides a data integrity layer for OHLCV data. It catches structural and logical issues in financial bar data before they silently corrupt exports, backtests, or downstream pipelines.
 
 ---
 
-## Import
+## Reference Pages
+
+| Page | Contents |
+|------|----------|
+| [`validate_ohlcv`](validate_ohlcv.md) | Function signature, parameters, schema contract, check order, gap detection behavior, selective checks |
+| [`Models`](models.md) | `ValidationResult`, `Violation`, `ViolationType`, `DataIntegrityError`, `ContextValue`, `ViolationContext` |
+
+---
+
+## Quick Import
 
 ```python
 from tvkit.validation import (
@@ -37,144 +32,8 @@ from tvkit.validation import (
 
 ---
 
-## `validate_ohlcv()`
+## See Also
 
-```python
-def validate_ohlcv(
-    df: pl.DataFrame,
-    *,
-    interval: str | None = None,
-    checks: list[ViolationType] | None = None,
-) -> ValidationResult:
-```
-
-Validates the integrity of an OHLCV Polars DataFrame.
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `df` | `pl.DataFrame` | — | DataFrame with required columns: `timestamp`, `open`, `high`, `low`, `close`, `volume` |
-| `interval` | `str \| None` | `None` | Interval string for gap detection (e.g. `"1D"`, `"1H"`, `"15"`). Required for `GAP_DETECTED` check. Silently skips gap detection if `None` and `GAP_DETECTED` is not in `checks`. |
-| `checks` | `list[ViolationType] \| None` | `None` | Subset of checks to run. If `None`, all applicable checks run. Execution always follows deterministic order regardless of list order. |
-
-### Returns
-
-`ValidationResult` — see [models reference](models.md).
-
-### Raises
-
-| Exception | Condition |
-|-----------|-----------|
-| `ValueError` | Required column missing or unsupported dtype |
-| `ValueError` | `ViolationType.GAP_DETECTED` in `checks` but `interval` is `None` |
-| `ValueError` | Unknown value in `checks` |
-
----
-
-## Required Schema
-
-`validate_ohlcv()` raises `ValueError` if the DataFrame does not meet the schema before any check runs.
-
-| Column | Accepted Polars Dtypes | Nullable |
-|--------|------------------------|----------|
-| `timestamp` | `Float64`, `Int64`, `Datetime(...)`, `Date` | No |
-| `open` | `Float64`, `Float32` | No |
-| `high` | `Float64`, `Float32` | No |
-| `low` | `Float64`, `Float32` | No |
-| `close` | `Float64`, `Float32` | No |
-| `volume` | `Float64`, `Float32`, `Int64` | No |
-
-**`Float64` timestamp note:** tvkit's `PolarsFormatter` produces `Float64` epoch-seconds timestamps. This is the canonical timestamp format for tvkit DataFrames.
-
-**`Int64` timestamp note:** Interpreted as epoch milliseconds (Polars convention). No conversion is performed — the caller is responsible for correct units.
-
-Empty DataFrames (0 rows) pass schema validation. All checks return empty violation lists.
-
----
-
-## Deterministic Check Order
-
-When `checks=None`, all applicable checks run in this fixed order:
-
-| # | `ViolationType` | Severity | Condition |
-|---|-----------------|----------|-----------|
-| 1 | `DUPLICATE_TIMESTAMP` | ERROR | Any timestamp appears more than once |
-| 2 | `NON_MONOTONIC_TIMESTAMP` | ERROR | Any consecutive pair where `ts[i] >= ts[i+1]` |
-| 3 | `OHLC_INCONSISTENCY` | ERROR | Any bar where `low > open`, `low > close`, `open > high`, or `close > high`, or any NaN in OHLC columns |
-| 4 | `NEGATIVE_VOLUME` | ERROR | Any bar with `volume < 0` or NaN volume |
-| 5 | `GAP_DETECTED` | WARNING | Any consecutive pair where timestamp difference exceeds the expected interval |
-
-Violations are sorted by this check order, then by row index within each check. This ordering is stable across releases.
-
----
-
-## Gap Detection Behavior
-
-| `interval` | `checks` | Behavior |
-|---|---|---|
-| `None` | `None` (all checks) | Gap detection silently skipped |
-| `"1D"` | `None` (all checks) | Gap detection runs |
-| `None` | `[ViolationType.GAP_DETECTED]` | Raises `ValueError` immediately |
-| `"1H"` | `[ViolationType.GAP_DETECTED]` | Gap detection runs |
-
-### Supported Interval Strings
-
-| String | Duration |
-|--------|----------|
-| `"1"` | 1 minute |
-| `"5"` | 5 minutes |
-| `"15"` | 15 minutes |
-| `"30"` | 30 minutes |
-| `"60"` / `"1H"` | 1 hour |
-| `"240"` / `"4H"` | 4 hours |
-| `"1D"` | 1 day |
-| `"1W"` | 1 week |
-| `"1M"` | 1 month (30 days) |
-
-### Phase 1 Calendar Limitation
-
-Gap detection in Phase 1 is **cadence-only and not calendar-aware**. For daily equity bars (`"1D"`), weekends and public holidays appear as `GAP_DETECTED` WARNING violations. These are expected and should be filtered by the caller if needed. Calendar-aware gap detection is planned as a future enhancement.
-
----
-
-## Selective Checks
-
-Run only a specific subset of checks:
-
-```python
-from tvkit.validation import validate_ohlcv, ViolationType
-
-# Only check for duplicates and OHLC inconsistencies
-result = validate_ohlcv(
-    df,
-    checks=[ViolationType.DUPLICATE_TIMESTAMP, ViolationType.OHLC_INCONSISTENCY],
-)
-
-# Only gap detection (interval required)
-result = validate_ohlcv(
-    df,
-    interval="1H",
-    checks=[ViolationType.GAP_DETECTED],
-)
-```
-
-Checks always execute in `_CHECK_ORDER` regardless of the order in the `checks` list.
-
----
-
-## DataExporter Integration
-
-`DataExporter.to_csv()` and `DataExporter.to_json()` accept opt-in validation via keyword-only parameters:
-
-```python
-exporter = DataExporter()
-
-# Logging mode: violations logged at WARNING, export always proceeds
-await exporter.to_csv(bars, "output.csv", validate=True, interval="1D")
-
-# Strict mode: DataIntegrityError raised on ERROR violations, file not written
-await exporter.to_csv(bars, "output.csv", validate=True, strict=True, interval="1D")
-```
-
-See [DataExporter reference](../export/exporter.md) and the [data validation guide](../../guides/data-validation.md) for full details.
+- [Data Validation guide](../../guides/data-validation.md) — workflow examples and common patterns
+- [Data Integrity concepts](../../concepts/data-integrity.md) — why validation matters and design rationale
+- [DataExporter reference](../export/exporter.md) — `validate`, `strict`, `interval` parameters

--- a/docs/reference/validation/models.md
+++ b/docs/reference/validation/models.md
@@ -1,0 +1,143 @@
+# Validation Models Reference
+
+**Module:** `tvkit.validation`
+**Introduced in:** v0.9.0
+
+Data models, enums, and exceptions used by the `tvkit.validation` module.
+
+---
+
+## `ViolationType`
+
+```python
+from tvkit.validation import ViolationType
+```
+
+`StrEnum` identifying the check that produced a violation. The string value is used in structured logging and serialization.
+
+```python
+class ViolationType(StrEnum):
+    DUPLICATE_TIMESTAMP = "duplicate_timestamp"
+    NON_MONOTONIC_TIMESTAMP = "non_monotonic_timestamp"
+    OHLC_INCONSISTENCY = "ohlc_inconsistency"
+    NEGATIVE_VOLUME = "negative_volume"
+    GAP_DETECTED = "gap_detected"
+```
+
+---
+
+## `Violation`
+
+```python
+from tvkit.validation import Violation
+```
+
+A single data integrity violation found in an OHLCV DataFrame.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `check` | `ViolationType` | The validation check that produced this violation |
+| `severity` | `Literal["ERROR", "WARNING"]` | Severity level |
+| `message` | `str` | Human-readable description |
+| `affected_rows` | `list[int]` | 0-based row indices in the input DataFrame |
+| `context` | `ViolationContext` | Structured context values (`str`, `int`, `float`, `bool`, or `None`) |
+
+### Severity Semantics
+
+| Severity | Effect on `ValidationResult.is_valid` | Meaning |
+|----------|--------------------------------------|---------|
+| `ERROR` | Sets `is_valid=False` | Structural data corruption — downstream pipelines cannot safely use this data |
+| `WARNING` | No effect (`is_valid` stays `True`) | Potentially expected condition — caller should acknowledge and decide |
+
+Currently, only `GAP_DETECTED` produces `WARNING` violations. All other checks produce `ERROR`.
+
+---
+
+## `ValidationResult`
+
+```python
+from tvkit.validation import ValidationResult
+```
+
+Aggregate result of all validation checks on an OHLCV DataFrame.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_valid` | `bool` | `True` iff zero ERROR violations. WARNING violations do not affect this flag. |
+| `violations` | `list[Violation]` | All violations in deterministic order (check order, then row index) |
+| `bars_checked` | `int` | Total number of bars examined |
+| `checks_run` | `list[ViolationType]` | Ordered list of checks executed |
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `.errors` | `list[Violation]` | Only ERROR-severity violations. Not serialized by `model_dump()`. |
+| `.warnings` | `list[Violation]` | Only WARNING-severity violations. Not serialized by `model_dump()`. |
+
+### Example
+
+```python
+result = validate_ohlcv(df, interval="1D")
+
+print(result.is_valid)           # True or False
+print(result.bars_checked)       # e.g. 252
+print(result.checks_run)         # [ViolationType.DUPLICATE_TIMESTAMP, ...]
+
+for v in result.errors:
+    logger.error(v.message, extra={"check": v.check.value, "rows": v.affected_rows})
+
+for v in result.warnings:
+    logger.warning(v.message, extra={"check": v.check.value, "rows": v.affected_rows})
+```
+
+---
+
+## `DataIntegrityError`
+
+```python
+from tvkit.validation import DataIntegrityError
+```
+
+Raised by `DataExporter` when `strict=True` and ERROR-level violations are found. Carries the full `ValidationResult` for structured error handling.
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `result` | `ValidationResult` | The full validation result with all violations |
+
+### Example
+
+```python
+try:
+    await exporter.to_csv(bars, "output.csv", validate=True, strict=True)
+except DataIntegrityError as e:
+    print(f"Found {len(e.result.errors)} error(s)")
+    for v in e.result.errors:
+        print(f"  [{v.check}] {v.message} (rows: {v.affected_rows})")
+```
+
+---
+
+## Type Aliases
+
+### `ContextValue`
+
+```python
+ContextValue = str | int | float | bool | None
+```
+
+A single value in a `Violation.context` dictionary. Restricted to JSON-serializable primitives.
+
+### `ViolationContext`
+
+```python
+ViolationContext = dict[str, ContextValue]
+```
+
+The type of `Violation.context`. Keys are strings; values are `ContextValue` (no nested dicts, no lists).

--- a/docs/reference/validation/validate_ohlcv.md
+++ b/docs/reference/validation/validate_ohlcv.md
@@ -1,0 +1,180 @@
+# `validate_ohlcv` Reference
+
+**Module:** `tvkit.validation`
+**Introduced in:** v0.9.0
+
+Validates the structural and logical integrity of an OHLCV Polars DataFrame. Returns a structured `ValidationResult` describing any violations found. All checks are pure functions with no side effects.
+
+## Quick Example
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+result = validate_ohlcv(df, interval="1D")
+
+if result.is_valid:
+    await exporter.to_csv(bars, "output.csv")
+else:
+    for v in result.errors:
+        logger.error(v.message, extra={"check": v.check, "rows": v.affected_rows})
+```
+
+---
+
+## Import
+
+```python
+from tvkit.validation import (
+    validate_ohlcv,
+    ValidationResult,
+    Violation,
+    ViolationType,
+    DataIntegrityError,
+    ContextValue,
+    ViolationContext,
+)
+```
+
+---
+
+## `validate_ohlcv()`
+
+```python
+def validate_ohlcv(
+    df: pl.DataFrame,
+    *,
+    interval: str | None = None,
+    checks: list[ViolationType] | None = None,
+) -> ValidationResult:
+```
+
+Validates the integrity of an OHLCV Polars DataFrame.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `df` | `pl.DataFrame` | — | DataFrame with required columns: `timestamp`, `open`, `high`, `low`, `close`, `volume` |
+| `interval` | `str \| None` | `None` | Interval string for gap detection (e.g. `"1D"`, `"1H"`, `"15"`). Required for `GAP_DETECTED` check. Silently skips gap detection if `None` and `GAP_DETECTED` is not in `checks`. |
+| `checks` | `list[ViolationType] \| None` | `None` | Subset of checks to run. If `None`, all applicable checks run. Execution always follows deterministic order regardless of list order. |
+
+### Returns
+
+`ValidationResult` — see [models reference](models.md).
+
+### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `ValueError` | Required column missing or unsupported dtype |
+| `ValueError` | `ViolationType.GAP_DETECTED` in `checks` but `interval` is `None` |
+| `ValueError` | Unknown value in `checks` |
+
+---
+
+## Required Schema
+
+`validate_ohlcv()` raises `ValueError` if the DataFrame does not meet the schema before any check runs.
+
+| Column | Accepted Polars Dtypes | Nullable |
+|--------|------------------------|----------|
+| `timestamp` | `Float64`, `Int64`, `Datetime(...)`, `Date` | No |
+| `open` | `Float64`, `Float32` | No |
+| `high` | `Float64`, `Float32` | No |
+| `low` | `Float64`, `Float32` | No |
+| `close` | `Float64`, `Float32` | No |
+| `volume` | `Float64`, `Float32`, `Int64` | No |
+
+**`Float64` timestamp note:** tvkit's `PolarsFormatter` produces `Float64` epoch-seconds timestamps. This is the canonical timestamp format for tvkit DataFrames.
+
+**`Int64` timestamp note:** Interpreted as epoch milliseconds (Polars convention). No conversion is performed — the caller is responsible for correct units.
+
+Empty DataFrames (0 rows) pass schema validation. All checks return empty violation lists.
+
+---
+
+## Deterministic Check Order
+
+When `checks=None`, all applicable checks run in this fixed order:
+
+| # | `ViolationType` | Severity | Condition |
+|---|-----------------|----------|-----------|
+| 1 | `DUPLICATE_TIMESTAMP` | ERROR | Any timestamp appears more than once |
+| 2 | `NON_MONOTONIC_TIMESTAMP` | ERROR | Any consecutive pair where `ts[i] >= ts[i+1]` |
+| 3 | `OHLC_INCONSISTENCY` | ERROR | Any bar where `low > open`, `low > close`, `open > high`, or `close > high`, or any NaN in OHLC columns |
+| 4 | `NEGATIVE_VOLUME` | ERROR | Any bar with `volume < 0` or NaN volume |
+| 5 | `GAP_DETECTED` | WARNING | Any consecutive pair where timestamp difference exceeds the expected interval |
+
+Violations are sorted by this check order, then by row index within each check. This ordering is stable across releases.
+
+---
+
+## Gap Detection Behavior
+
+| `interval` | `checks` | Behavior |
+|---|---|---|
+| `None` | `None` (all checks) | Gap detection silently skipped |
+| `"1D"` | `None` (all checks) | Gap detection runs |
+| `None` | `[ViolationType.GAP_DETECTED]` | Raises `ValueError` immediately |
+| `"1H"` | `[ViolationType.GAP_DETECTED]` | Gap detection runs |
+
+### Supported Interval Strings
+
+| String | Duration |
+|--------|----------|
+| `"1"` | 1 minute |
+| `"5"` | 5 minutes |
+| `"15"` | 15 minutes |
+| `"30"` | 30 minutes |
+| `"60"` / `"1H"` | 1 hour |
+| `"240"` / `"4H"` | 4 hours |
+| `"1D"` | 1 day |
+| `"1W"` | 1 week |
+| `"1M"` | 1 month (30 days) |
+
+### Phase 1 Calendar Limitation
+
+Gap detection in Phase 1 is **cadence-only and not calendar-aware**. For daily equity bars (`"1D"`), weekends and public holidays appear as `GAP_DETECTED` WARNING violations. These are expected and should be filtered by the caller if needed. Calendar-aware gap detection is planned as a future enhancement.
+
+---
+
+## Selective Checks
+
+Run only a specific subset of checks:
+
+```python
+from tvkit.validation import validate_ohlcv, ViolationType
+
+# Only check for duplicates and OHLC inconsistencies
+result = validate_ohlcv(
+    df,
+    checks=[ViolationType.DUPLICATE_TIMESTAMP, ViolationType.OHLC_INCONSISTENCY],
+)
+
+# Only gap detection (interval required)
+result = validate_ohlcv(
+    df,
+    interval="1H",
+    checks=[ViolationType.GAP_DETECTED],
+)
+```
+
+Checks always execute in `_CHECK_ORDER` regardless of the order in the `checks` list.
+
+---
+
+## DataExporter Integration
+
+`DataExporter.to_csv()` and `DataExporter.to_json()` accept opt-in validation via keyword-only parameters:
+
+```python
+exporter = DataExporter()
+
+# Logging mode: violations logged at WARNING, export always proceeds
+await exporter.to_csv(bars, "output.csv", validate=True, interval="1D")
+
+# Strict mode: DataIntegrityError raised on ERROR violations, file not written
+await exporter.to_csv(bars, "output.csv", validate=True, strict=True, interval="1D")
+```
+
+See [DataExporter reference](../export/exporter.md) and the [data validation guide](../../guides/data-validation.md) for full details.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 
 ## Recently Shipped
 
+- **v0.9.0** — Data Integrity Validation (`tvkit.validation`: duplicate/monotonic/OHLC/volume/gap checks; `DataExporter` integration with `validate`, `strict`, `interval` parameters)
 - **v0.8.0** —  Symbol Normalization 
 - **v0.7.0** — Authentication
 - **v0.6.0** — Timezone Handling
@@ -22,26 +23,6 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 ---
 
 ## In Progress
-
----
-
-#### Data Integrity Validation
-
-Validation utilities to guarantee OHLCV data consistency before caching, exporting, or analysis.
-
-Checks may include:
-
-- Monotonic timestamps
-- Duplicate bars
-- OHLC consistency (`low ≤ open ≤ close ≤ high`)
-- Non-negative volume
-- Gap detection
-
-Proposed module: `tvkit.validation`
-
-```python
-validate_ohlcv(df)
-```
 
 ---
 

--- a/examples/validation_ohlcv.py
+++ b/examples/validation_ohlcv.py
@@ -1,0 +1,104 @@
+"""
+OHLCV Data Integrity Validation
+
+Primary example: fetch → validate → export workflow using tvkit.validation.
+
+This script uses synthetic continuous-market data (hourly bars, no calendar gaps)
+to demonstrate the full validation pipeline cleanly. For a comprehensive multi-demo
+walkthrough including strict mode, programmatic handling, and selective checks, see
+examples/validation_ohlcv_example.py.
+
+Run:
+    uv run python examples/validation_ohlcv.py
+"""
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+import polars as pl
+
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.export import DataExporter
+from tvkit.validation import DataIntegrityError, validate_ohlcv
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)-8s %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# 2024-01-01 00:00:00 UTC in epoch seconds
+_BASE_TS = 1_704_067_200.0
+_ONE_HOUR = 3_600.0
+
+
+def make_hourly_bars(n: int = 24) -> list[OHLCVBar]:
+    """Generate n clean hourly bars (continuous market — no calendar gaps)."""
+    return [
+        OHLCVBar(
+            timestamp=_BASE_TS + i * _ONE_HOUR,
+            open=100.0 + i * 0.5,
+            high=102.0 + i * 0.5,
+            low=99.0 + i * 0.5,
+            close=101.0 + i * 0.5,
+            volume=50_000.0 + i * 500,
+        )
+        for i in range(n)
+    ]
+
+
+async def main() -> None:
+    bars = make_hourly_bars(n=24)
+    exporter = DataExporter()
+
+    # ------------------------------------------------------------------
+    # 1. Standalone validation — inspect the result before exporting
+    # ------------------------------------------------------------------
+    df = pl.DataFrame(
+        {
+            "timestamp": [b.timestamp for b in bars],
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+    result = validate_ohlcv(df, interval="1H")
+    logger.info(
+        "Validation result: is_valid=%s, bars_checked=%d, violations=%d",
+        result.is_valid,
+        result.bars_checked,
+        len(result.violations),
+    )
+
+    if not result.is_valid:
+        for v in result.errors:
+            logger.error(v.message, extra={"check": v.check.value, "rows": v.affected_rows})
+        return
+
+    # ------------------------------------------------------------------
+    # 2. Export with validation gate (strict mode — blocks on ERROR violations)
+    # ------------------------------------------------------------------
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "ohlcv_1h.csv"
+        try:
+            written = await exporter.to_csv(
+                bars,
+                out,
+                validate=True,
+                strict=True,
+                interval="1H",
+            )
+            logger.info("Exported clean data to: %s", written.name)
+        except DataIntegrityError as e:
+            logger.error(
+                "Export blocked: %d error(s) found in %d bars",
+                len(e.result.errors),
+                e.result.bars_checked,
+            )
+            for v in e.result.errors:
+                logger.error("  [%s] %s — rows: %s", v.check.value, v.message, v.affected_rows)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/validation_ohlcv_example.py
+++ b/examples/validation_ohlcv_example.py
@@ -1,0 +1,393 @@
+"""
+Data Integrity Validation Example
+
+Demonstrates tvkit.validation usage patterns:
+  1. Standalone validate_ohlcv() — inspect violations directly
+  2. DataExporter.to_csv(validate=True, strict=False) — logging mode: violations logged,
+     export proceeds even when ERROR violations are found
+  3. DataExporter.to_csv(validate=True, strict=True) — strict mode: errors block export,
+     file is not written
+  4. Programmatic violation handling
+
+Note on OHLCVBar and OHLC validation:
+  OHLCVBar validates only the timestamp field at construction time. It does NOT enforce
+  OHLC constraints (low <= open/close <= high). These structural checks are the
+  responsibility of tvkit.validation, which is why they are caught at the DataExporter
+  level rather than during bar construction.
+
+Prerequisites:
+  uv run python examples/validation_ohlcv_example.py
+"""
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+import polars as pl
+
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.export import DataExporter
+from tvkit.validation import (
+    DataIntegrityError,
+    ValidationResult,
+    ViolationType,
+    validate_ohlcv,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)-8s %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+BASE_TS = 1_672_531_200.0  # 2023-01-01 UTC
+
+
+# ---------------------------------------------------------------------------
+# Shared bar factories
+# ---------------------------------------------------------------------------
+
+
+def make_clean_bars(n: int = 10) -> list[OHLCVBar]:
+    """Valid OHLCV bars: monotonic timestamps, valid OHLC, positive volume."""
+    return [
+        OHLCVBar(
+            timestamp=BASE_TS + i * 86_400.0,
+            open=100.0 + i,
+            high=110.0 + i,
+            low=90.0 + i,
+            close=105.0 + i,
+            volume=10_000.0 + i * 100,
+        )
+        for i in range(n)
+    ]
+
+
+def make_ohlc_error_bars(n: int = 10) -> list[OHLCVBar]:
+    """
+    OHLCV bars where some bars have open > high (OHLC_INCONSISTENCY ERROR).
+
+    OHLCVBar does not enforce OHLC constraints at construction time — that is
+    the job of tvkit.validation. These bars are created without error here.
+    """
+    bars = make_clean_bars(n)
+    # Inject violations: open > high on bars 2 and 7
+    bars[2] = OHLCVBar(
+        timestamp=BASE_TS + 2 * 86_400.0,
+        open=130.0,  # exceeds high=112.0 → OHLC ERROR
+        high=112.0,
+        low=92.0,
+        close=107.0,
+        volume=10_200.0,
+    )
+    bars[7] = OHLCVBar(
+        timestamp=BASE_TS + 7 * 86_400.0,
+        open=130.0,  # exceeds high=117.0 → OHLC ERROR
+        high=117.0,
+        low=97.0,
+        close=112.0,
+        volume=10_700.0,
+    )
+    return bars
+
+
+def make_gapped_bars() -> list[OHLCVBar]:
+    """
+    OHLCV bars with a 3-day gap between bar 3 and bar 4.
+    Produces GAP_DETECTED WARNING (not ERROR). is_valid stays True.
+    """
+    return [
+        OHLCVBar(
+            timestamp=BASE_TS + 0 * 86_400.0,
+            open=100.0,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=10_000.0,
+        ),
+        OHLCVBar(
+            timestamp=BASE_TS + 1 * 86_400.0,
+            open=101.0,
+            high=111.0,
+            low=91.0,
+            close=106.0,
+            volume=10_100.0,
+        ),
+        OHLCVBar(
+            timestamp=BASE_TS + 2 * 86_400.0,
+            open=102.0,
+            high=112.0,
+            low=92.0,
+            close=107.0,
+            volume=10_200.0,
+        ),
+        # 3-day gap here → GAP_DETECTED WARNING
+        OHLCVBar(
+            timestamp=BASE_TS + 5 * 86_400.0,
+            open=105.0,
+            high=115.0,
+            low=95.0,
+            close=110.0,
+            volume=10_500.0,
+        ),
+        OHLCVBar(
+            timestamp=BASE_TS + 6 * 86_400.0,
+            open=106.0,
+            high=116.0,
+            low=96.0,
+            close=111.0,
+            volume=10_600.0,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Standalone validate_ohlcv()
+# ---------------------------------------------------------------------------
+
+
+def demo_standalone_validation() -> None:
+    """Demonstrate using validate_ohlcv() directly on a Polars DataFrame."""
+    logger.info("=" * 60)
+    logger.info("DEMO 1: Standalone validate_ohlcv()")
+    logger.info("=" * 60)
+
+    # --- Clean data ---
+    bars = make_clean_bars()
+    df = pl.DataFrame(
+        {
+            "timestamp": [b.timestamp for b in bars],
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+    result: ValidationResult = validate_ohlcv(df, interval="1D")
+    logger.info(
+        "Clean DataFrame: is_valid=%s, bars_checked=%d, violations=%d",
+        result.is_valid,
+        result.bars_checked,
+        len(result.violations),
+    )
+    assert result.is_valid
+    assert result.violations == []
+
+    # --- OHLC error data ---
+    bars = make_ohlc_error_bars()
+    df = pl.DataFrame(
+        {
+            "timestamp": [b.timestamp for b in bars],
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+    result = validate_ohlcv(df)
+    logger.info(
+        "OHLC-error DataFrame: is_valid=%s, errors=%d",
+        result.is_valid,
+        len(result.errors),
+    )
+    for v in result.errors:
+        logger.info(
+            "  [%s] %s — rows: %s, context: %s",
+            v.check.value,
+            v.message,
+            v.affected_rows,
+            v.context,
+        )
+    assert not result.is_valid
+    # Bars 2 and 7 are affected — check by row index, not by count (count is implementation detail)
+    error_rows = {row for v in result.errors for row in v.affected_rows}
+    assert 2 in error_rows, f"Expected row 2 in error rows, got {error_rows}"
+    assert 7 in error_rows, f"Expected row 7 in error rows, got {error_rows}"
+    assert any(v.check == ViolationType.OHLC_INCONSISTENCY for v in result.errors)
+
+    # --- Gap warning (WARNING-only, is_valid stays True) ---
+    bars = make_gapped_bars()
+    df = pl.DataFrame(
+        {
+            "timestamp": [b.timestamp for b in bars],
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+    result = validate_ohlcv(df, interval="1D")
+    logger.info(
+        "Gapped DataFrame: is_valid=%s, warnings=%d",
+        result.is_valid,
+        len(result.warnings),
+    )
+    assert result.is_valid  # WARNING does not affect is_valid
+    assert any(v.check == ViolationType.GAP_DETECTED for v in result.warnings)
+
+    logger.info("Demo 1 complete.\n")
+
+
+# ---------------------------------------------------------------------------
+# 2. DataExporter.to_csv(validate=True, strict=False) — logging mode
+# ---------------------------------------------------------------------------
+
+
+async def demo_export_logging_mode() -> None:
+    """
+    validate=True, strict=False (default):
+    Violations are logged at WARNING level, but the export always proceeds.
+    Even ERROR violations do not block the file write.
+    """
+    logger.info("=" * 60)
+    logger.info("DEMO 2: to_csv(validate=True, strict=False) — logging mode")
+    logger.info("=" * 60)
+
+    # Use bars WITH OHLC errors — violations will be logged, but file is written anyway
+    bars = make_ohlc_error_bars()
+    exporter = DataExporter()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = await exporter.to_csv(
+            bars,
+            Path(tmpdir) / "ohlc_errors.csv",
+            validate=True,
+            strict=False,  # violations logged, export proceeds
+        )
+        # File is written despite ERROR violations
+        assert out.exists(), "File must be written in non-strict mode"
+        logger.info(
+            "Export succeeded (strict=False): %s — violations logged above as WARNING",
+            out.name,
+        )
+
+    logger.info("Demo 2 complete.\n")
+
+
+# ---------------------------------------------------------------------------
+# 3. DataExporter.to_csv(validate=True, strict=True) — strict mode
+# ---------------------------------------------------------------------------
+
+
+async def demo_export_strict_mode() -> None:
+    """
+    validate=True, strict=True:
+    DataIntegrityError is raised on ERROR violations. The file is NOT written.
+    """
+    logger.info("=" * 60)
+    logger.info("DEMO 3: to_csv(validate=True, strict=True) — strict mode")
+    logger.info("=" * 60)
+
+    # OHLCVBar does not validate OHLC constraints at construction time.
+    # These bars are created successfully; OHLC errors are caught by validate_ohlcv().
+    bars = make_ohlc_error_bars()
+    exporter = DataExporter()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "should_not_exist.csv"
+        try:
+            await exporter.to_csv(
+                bars,
+                out_path,
+                validate=True,
+                strict=True,
+            )
+            raise AssertionError("Expected DataIntegrityError — should not reach here")
+        except DataIntegrityError as e:
+            logger.info(
+                "Export blocked (strict=True): %d error(s) in %d bars",
+                len(e.result.errors),
+                e.result.bars_checked,
+            )
+            for v in e.result.errors:
+                logger.info(
+                    "  [%s] %s — rows: %s",
+                    v.check.value,
+                    v.message,
+                    v.affected_rows,
+                )
+            assert not out_path.exists(), (
+                "File must NOT be written when DataIntegrityError is raised"
+            )
+            logger.info("Confirmed: output file was NOT written.")
+
+    logger.info("Demo 3 complete.\n")
+
+
+# ---------------------------------------------------------------------------
+# 4. Programmatic violation handling
+# ---------------------------------------------------------------------------
+
+
+def demo_programmatic_handling() -> None:
+    """
+    Use validate_ohlcv() directly for custom handling:
+    - Separate errors from warnings
+    - Extract affected row indices for downstream repair
+    - Check specific violation types
+    - Inspect serialized form (model_dump excludes .errors / .warnings properties)
+    """
+    logger.info("=" * 60)
+    logger.info("DEMO 4: Programmatic violation handling")
+    logger.info("=" * 60)
+
+    bars = make_ohlc_error_bars()
+    df = pl.DataFrame(
+        {
+            "timestamp": [b.timestamp for b in bars],
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+    result = validate_ohlcv(
+        df,
+        checks=[
+            ViolationType.DUPLICATE_TIMESTAMP,
+            ViolationType.OHLC_INCONSISTENCY,
+            ViolationType.NEGATIVE_VOLUME,
+        ],
+    )
+
+    # Separate by severity
+    logger.info("Errors: %d, Warnings: %d", len(result.errors), len(result.warnings))
+
+    # Collect all affected rows across all ERROR violations
+    error_rows = sorted({row for v in result.errors for row in v.affected_rows})
+    logger.info("Rows with errors: %s", error_rows)
+
+    # Check for a specific violation type
+    has_ohlc_errors = any(v.check == ViolationType.OHLC_INCONSISTENCY for v in result.errors)
+    logger.info("OHLC violations present: %s", has_ohlc_errors)
+    assert has_ohlc_errors
+
+    # model_dump() for serialization — .errors and .warnings are @property, not serialized
+    dump = result.model_dump()
+    logger.info("Serialized keys: %s", list(dump.keys()))
+    assert "errors" not in dump, "errors must not appear in model_dump()"
+    assert "warnings" not in dump, "warnings must not appear in model_dump()"
+
+    # Checks run are in deterministic order (subset of _CHECK_ORDER)
+    logger.info("Checks run: %s", [c.value for c in result.checks_run])
+
+    logger.info("Demo 4 complete.\n")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    demo_standalone_validation()
+    await demo_export_logging_mode()
+    await demo_export_strict_mode()
+    demo_programmatic_handling()
+    logger.info("All demos complete.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvkit"
-version = "0.8.0"
+version = "0.9.0"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -104,10 +104,12 @@ asyncio_mode = "strict"
 
 [dependency-groups]
 dev = [
+    "build>=1.3.0",
     "mypy>=1.17.1",
     "pre-commit>=4.5.1",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.1.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.12.12",
+    "twine>=6.2.0",
 ]

--- a/tests/test_export_validation.py
+++ b/tests/test_export_validation.py
@@ -9,4 +9,570 @@ Tests for:
 - to_csv(validate=True, strict=True) does NOT raise on WARNING-only results
 - DataIntegrityError.result carries the full ValidationResult
 - strict=True does not write the file on ERROR violations
+- scanner data silently skips validation
+- interval is forwarded to validate_ohlcv
+- violations are logged at WARNING with structured extra fields
 """
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.api.scanner.models import StockData
+from tvkit.export import DataExporter
+from tvkit.validation import DataIntegrityError, ValidationResult, Violation, ViolationType
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_ohlcv_bars() -> list[OHLCVBar]:
+    """Valid OHLCV bars: monotonic timestamps, valid OHLC, positive volume."""
+    base_ts = 1_672_531_200.0  # 2023-01-01 UTC
+    return [
+        OHLCVBar(
+            timestamp=base_ts + i * 86_400.0,
+            open=100.0 + i,
+            high=110.0 + i,
+            low=90.0 + i,
+            close=105.0 + i,
+            volume=1_000.0 + i,
+        )
+        for i in range(5)
+    ]
+
+
+@pytest.fixture
+def ohlcv_bars_with_error() -> list[OHLCVBar]:
+    """OHLCV bars with one OHLC ERROR violation (open > high on bar 1)."""
+    base_ts = 1_672_531_200.0
+    bars = [
+        OHLCVBar(
+            timestamp=base_ts + i * 86_400.0,
+            open=100.0 + i,
+            high=110.0 + i,
+            low=90.0 + i,
+            close=105.0 + i,
+            volume=1_000.0 + i,
+        )
+        for i in range(5)
+    ]
+    # Inject OHLC violation on bar 1: open > high
+    bars[1] = OHLCVBar(
+        timestamp=base_ts + 86_400.0,
+        open=120.0,  # open > high → ERROR
+        high=110.0,
+        low=90.0,
+        close=105.0,
+        volume=1_000.0,
+    )
+    return bars
+
+
+@pytest.fixture
+def ohlcv_bars_with_gap_warning() -> list[OHLCVBar]:
+    """
+    OHLCV bars with a timestamp gap — produces GAP_DETECTED (WARNING) only.
+
+    The gap is 3 days between bar 2 and bar 3 when cadence is 1D.
+    """
+    base_ts = 1_672_531_200.0
+    return [
+        OHLCVBar(
+            timestamp=base_ts + 0 * 86_400.0,
+            open=100.0,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=1_000.0,
+        ),
+        OHLCVBar(
+            timestamp=base_ts + 1 * 86_400.0,
+            open=101.0,
+            high=111.0,
+            low=91.0,
+            close=106.0,
+            volume=1_001.0,
+        ),
+        OHLCVBar(
+            # 3-day gap (2 missing bars) → GAP_DETECTED WARNING
+            timestamp=base_ts + 4 * 86_400.0,
+            open=104.0,
+            high=114.0,
+            low=94.0,
+            close=109.0,
+            volume=1_004.0,
+        ),
+        OHLCVBar(
+            timestamp=base_ts + 5 * 86_400.0,
+            open=105.0,
+            high=115.0,
+            low=95.0,
+            close=110.0,
+            volume=1_005.0,
+        ),
+    ]
+
+
+@pytest.fixture
+def scanner_stocks() -> list[StockData]:
+    """Minimal scanner data for testing validation skip."""
+    return [StockData(name="AAPL"), StockData(name="MSFT")]
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a ValidationResult with violations of given severities
+# ---------------------------------------------------------------------------
+
+
+def _make_validation_result(*, errors: int = 0, warnings: int = 0) -> ValidationResult:
+    """Build a ValidationResult with the requested number of violations."""
+    violations: list[Violation] = []
+    for i in range(errors):
+        violations.append(
+            Violation(
+                check=ViolationType.OHLC_INCONSISTENCY,
+                severity="ERROR",
+                message=f"OHLC error #{i}",
+                affected_rows=[i],
+                context={},
+            )
+        )
+    for i in range(warnings):
+        violations.append(
+            Violation(
+                check=ViolationType.GAP_DETECTED,
+                severity="WARNING",
+                message=f"Gap warning #{i}",
+                affected_rows=[i],
+                context={},
+            )
+        )
+    return ValidationResult(
+        is_valid=errors == 0,
+        violations=violations,
+        bars_checked=10,
+        checks_run=[ViolationType.OHLC_INCONSISTENCY],
+    )
+
+
+# ===========================================================================
+# Tests: DataExporter.to_csv() validation integration
+# ===========================================================================
+
+
+class TestDataExporterValidationToCsv:
+    """Integration tests for DataExporter.to_csv() validation parameters."""
+
+    @pytest.mark.asyncio
+    async def test_validate_false_skips_validation(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=False (default) does not call validate_ohlcv."""
+        exporter = DataExporter()
+        with patch("tvkit.export.data_exporter.validate_ohlcv") as mock_validate:
+            await exporter.to_csv(clean_ohlcv_bars, tmp_path / "out.csv")
+        mock_validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_false_explicit_skips_validation(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """Explicitly passing validate=False does not call validate_ohlcv."""
+        exporter = DataExporter()
+        with patch("tvkit.export.data_exporter.validate_ohlcv") as mock_validate:
+            await exporter.to_csv(clean_ohlcv_bars, tmp_path / "out.csv", validate=False)
+        mock_validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_true_calls_validate_ohlcv(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True calls validate_ohlcv exactly once before export."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result()
+        with patch(
+            "tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result
+        ) as mock_validate:
+            await exporter.to_csv(clean_ohlcv_bars, tmp_path / "out.csv", validate=True)
+        mock_validate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_validate_true_clean_data_exports(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """Clean data: validate=True passes validation and file is written."""
+        exporter = DataExporter()
+        out = await exporter.to_csv(clean_ohlcv_bars, tmp_path / "out.csv", validate=True)
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_validate_strict_false_exports_despite_errors(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True, strict=False: ERROR violations are logged but file is written."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(errors=1)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            out = await exporter.to_csv(
+                clean_ohlcv_bars,
+                tmp_path / "out.csv",
+                validate=True,
+                strict=False,
+            )
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_validate_strict_true_raises_on_errors(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True, strict=True: DataIntegrityError raised on ERROR violations."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(errors=2)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with pytest.raises(DataIntegrityError):
+                await exporter.to_csv(
+                    clean_ohlcv_bars,
+                    tmp_path / "out.csv",
+                    validate=True,
+                    strict=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_validate_strict_true_no_raise_on_warnings_only(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True, strict=True: WARNING-only result does NOT raise; file written."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(warnings=3)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            out = await exporter.to_csv(
+                clean_ohlcv_bars,
+                tmp_path / "out.csv",
+                validate=True,
+                strict=True,
+            )
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_data_integrity_error_carries_result(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """DataIntegrityError.result holds the full ValidationResult."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(errors=1)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with pytest.raises(DataIntegrityError) as exc_info:
+                await exporter.to_csv(
+                    clean_ohlcv_bars,
+                    tmp_path / "out.csv",
+                    validate=True,
+                    strict=True,
+                )
+        assert exc_info.value.result is mock_result
+        assert len(exc_info.value.result.errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_strict_true_does_not_write_file_on_errors(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """When strict=True and errors found, file is NOT written."""
+        exporter = DataExporter()
+        out_path = tmp_path / "should_not_exist.csv"
+        mock_result = _make_validation_result(errors=1)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with pytest.raises(DataIntegrityError):
+                await exporter.to_csv(clean_ohlcv_bars, out_path, validate=True, strict=True)
+        assert not out_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_validate_with_interval_passed_through(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """interval is forwarded to validate_ohlcv for gap detection."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result()
+        with patch(
+            "tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result
+        ) as mock_validate:
+            await exporter.to_csv(
+                clean_ohlcv_bars,
+                tmp_path / "out.csv",
+                validate=True,
+                interval="1D",
+            )
+        _, kwargs = mock_validate.call_args
+        assert kwargs.get("interval") == "1D"
+
+    @pytest.mark.asyncio
+    async def test_scanner_data_skips_validation(
+        self, scanner_stocks: list[StockData], tmp_path: Path
+    ) -> None:
+        """validate=True with scanner data silently skips validation."""
+        exporter = DataExporter()
+        with patch("tvkit.export.data_exporter.validate_ohlcv") as mock_validate:
+            await exporter.to_csv(
+                scanner_stocks,  # type: ignore[arg-type]
+                tmp_path / "out.csv",
+                validate=True,
+            )
+        mock_validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_list_skips_validation(self, tmp_path: Path) -> None:
+        """validate=True with an empty list silently skips validation."""
+        exporter = DataExporter()
+        with patch("tvkit.export.data_exporter.validate_ohlcv") as mock_validate:
+            # Empty list export may fail (no formatter output), but validation should not run
+            try:
+                await exporter.to_csv(
+                    [],  # type: ignore[arg-type]
+                    tmp_path / "out.csv",
+                    validate=True,
+                )
+            except (RuntimeError, Exception):
+                pass  # Export itself may fail on empty input — that is expected
+        mock_validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_violations_logged_at_warning_with_extra_fields(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """Violations are logged at WARNING level with check (str) and rows extra fields."""
+        exporter = DataExporter()
+        violation = Violation(
+            check=ViolationType.OHLC_INCONSISTENCY,
+            severity="ERROR",
+            message="open exceeds high",
+            affected_rows=[1],
+            context={},
+        )
+        mock_result = ValidationResult(
+            is_valid=False,
+            violations=[violation],
+            bars_checked=5,
+            checks_run=[ViolationType.OHLC_INCONSISTENCY],
+        )
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with patch("tvkit.export.data_exporter.logger") as mock_logger:
+                with pytest.raises(DataIntegrityError):
+                    await exporter.to_csv(
+                        clean_ohlcv_bars,
+                        tmp_path / "out.csv",
+                        validate=True,
+                        strict=True,
+                    )
+
+        mock_logger.warning.assert_called_once_with(
+            "open exceeds high",
+            extra={
+                "check": ViolationType.OHLC_INCONSISTENCY.value,
+                "rows": [1],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_check_value_in_log_is_string(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """The 'check' field in the log extra is a plain string, not an enum object."""
+        exporter = DataExporter()
+        violation = Violation(
+            check=ViolationType.DUPLICATE_TIMESTAMP,
+            severity="ERROR",
+            message="duplicate",
+            affected_rows=[0],
+            context={},
+        )
+        mock_result = ValidationResult(
+            is_valid=False,
+            violations=[violation],
+            bars_checked=5,
+            checks_run=[ViolationType.DUPLICATE_TIMESTAMP],
+        )
+        logged_calls: list[dict] = []
+
+        def capture_warning(msg: str, **kwargs: object) -> None:
+            extra = kwargs.get("extra", {})
+            logged_calls.append({"msg": msg, "extra": extra})
+
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with patch("tvkit.export.data_exporter.logger") as mock_logger:
+                mock_logger.warning.side_effect = capture_warning
+                with pytest.raises(DataIntegrityError):
+                    await exporter.to_csv(
+                        clean_ohlcv_bars,
+                        tmp_path / "out.csv",
+                        validate=True,
+                        strict=True,
+                    )
+
+        assert len(logged_calls) == 1
+        check_val = logged_calls[0]["extra"]["check"]
+        assert isinstance(check_val, str)
+        assert check_val == "duplicate_timestamp"
+
+    @pytest.mark.asyncio
+    async def test_real_ohlcv_error_raises_on_strict(
+        self, ohlcv_bars_with_error: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """End-to-end: real OHLC error bars + strict=True raises DataIntegrityError."""
+        exporter = DataExporter()
+        with pytest.raises(DataIntegrityError) as exc_info:
+            await exporter.to_csv(
+                ohlcv_bars_with_error,
+                tmp_path / "out.csv",
+                validate=True,
+                strict=True,
+            )
+        assert not exc_info.value.result.is_valid
+        assert len(exc_info.value.result.errors) >= 1
+
+    @pytest.mark.asyncio
+    async def test_real_gap_warning_does_not_raise_on_strict(
+        self, ohlcv_bars_with_gap_warning: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """End-to-end: gap warning + strict=True does NOT raise; file is written."""
+        exporter = DataExporter()
+        out = await exporter.to_csv(
+            ohlcv_bars_with_gap_warning,
+            tmp_path / "out.csv",
+            validate=True,
+            strict=True,
+            interval="1D",
+        )
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_multiple_violations_each_logged(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """Each violation generates one logger.warning call."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(errors=3)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with patch("tvkit.export.data_exporter.logger") as mock_logger:
+                with pytest.raises(DataIntegrityError):
+                    await exporter.to_csv(
+                        clean_ohlcv_bars,
+                        tmp_path / "out.csv",
+                        validate=True,
+                        strict=True,
+                    )
+        assert mock_logger.warning.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_validate_no_interval_skips_gap_detection(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True without interval: gap detection silently skipped in validate_ohlcv."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result()
+        with patch(
+            "tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result
+        ) as mock_validate:
+            await exporter.to_csv(clean_ohlcv_bars, tmp_path / "out.csv", validate=True)
+        _, kwargs = mock_validate.call_args
+        assert kwargs.get("interval") is None
+
+
+# ===========================================================================
+# Tests: DataExporter.to_json() validation integration
+# ===========================================================================
+
+
+class TestDataExporterValidationToJson:
+    """Integration tests for DataExporter.to_json() validation parameters."""
+
+    @pytest.mark.asyncio
+    async def test_validate_false_skips_validation(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=False (default) does not call validate_ohlcv."""
+        exporter = DataExporter()
+        with patch("tvkit.export.data_exporter.validate_ohlcv") as mock_validate:
+            await exporter.to_json(clean_ohlcv_bars, tmp_path / "out.json")
+        mock_validate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_strict_true_raises_on_errors(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True, strict=True: DataIntegrityError raised on ERROR violations."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(errors=1)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with pytest.raises(DataIntegrityError):
+                await exporter.to_json(
+                    clean_ohlcv_bars,
+                    tmp_path / "out.json",
+                    validate=True,
+                    strict=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_validate_strict_true_no_raise_on_warnings_only(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """validate=True, strict=True: WARNING-only does not raise; file written."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result(warnings=2)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            out = await exporter.to_json(
+                clean_ohlcv_bars,
+                tmp_path / "out.json",
+                validate=True,
+                strict=True,
+            )
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_strict_true_does_not_write_file_on_errors(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """When strict=True and errors found, JSON file is NOT written."""
+        exporter = DataExporter()
+        out_path = tmp_path / "should_not_exist.json"
+        mock_result = _make_validation_result(errors=1)
+        with patch("tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result):
+            with pytest.raises(DataIntegrityError):
+                await exporter.to_json(clean_ohlcv_bars, out_path, validate=True, strict=True)
+        assert not out_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_validate_with_interval_passed_through(
+        self, clean_ohlcv_bars: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """interval is forwarded to validate_ohlcv for gap detection."""
+        exporter = DataExporter()
+        mock_result = _make_validation_result()
+        with patch(
+            "tvkit.export.data_exporter.validate_ohlcv", return_value=mock_result
+        ) as mock_validate:
+            await exporter.to_json(
+                clean_ohlcv_bars,
+                tmp_path / "out.json",
+                validate=True,
+                interval="1H",
+            )
+        _, kwargs = mock_validate.call_args
+        assert kwargs.get("interval") == "1H"
+
+    @pytest.mark.asyncio
+    async def test_real_ohlcv_error_raises_on_strict(
+        self, ohlcv_bars_with_error: list[OHLCVBar], tmp_path: Path
+    ) -> None:
+        """End-to-end: real OHLC error bars + strict=True raises DataIntegrityError."""
+        exporter = DataExporter()
+        with pytest.raises(DataIntegrityError) as exc_info:
+            await exporter.to_json(
+                ohlcv_bars_with_error,
+                tmp_path / "out.json",
+                validate=True,
+                strict=True,
+            )
+        assert len(exc_info.value.result.errors) >= 1

--- a/tests/test_export_validation.py
+++ b/tests/test_export_validation.py
@@ -1,0 +1,12 @@
+"""
+Integration tests for DataExporter validation integration (Phase 3).
+
+Tests for:
+- to_csv(validate=False) skips validation
+- to_csv(validate=True) logs violations
+- to_csv(validate=True, strict=False) exports despite ERROR violations
+- to_csv(validate=True, strict=True) raises DataIntegrityError on ERROR violations
+- to_csv(validate=True, strict=True) does NOT raise on WARNING-only results
+- DataIntegrityError.result carries the full ValidationResult
+- strict=True does not write the file on ERROR violations
+"""

--- a/tests/test_validation_checks.py
+++ b/tests/test_validation_checks.py
@@ -1,0 +1,10 @@
+"""
+Unit tests for tvkit.validation individual check functions.
+
+Tests for:
+- check_duplicate_timestamps
+- check_monotonic_timestamps
+- check_ohlc_consistency
+- check_volume_non_negative
+- check_gaps
+"""

--- a/tests/test_validation_checks.py
+++ b/tests/test_validation_checks.py
@@ -7,4 +7,679 @@ Tests for:
 - check_ohlc_consistency
 - check_volume_non_negative
 - check_gaps
+
+Gap detection note: check_gaps() raises ValueError for weekly ("W", "1W") and
+monthly ("M", "1M") intervals because interval_to_seconds() does not support
+variable-cadence intervals. This is intentional — cadence-based gap detection
+has no meaningful interpretation for intervals with variable durations.
 """
+
+from datetime import UTC, date, datetime, timedelta
+
+import polars as pl
+import pytest
+
+from tvkit.validation.checks import (
+    check_duplicate_timestamps,
+    check_gaps,
+    check_monotonic_timestamps,
+    check_ohlc_consistency,
+    check_volume_non_negative,
+)
+from tvkit.validation.models import ViolationType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_TS = 1_700_000_000.0  # 2023-11-14 22:13:20 UTC (Float64 epoch seconds)
+_DAY = 86_400
+
+
+def _make_df(
+    timestamps: list[float],
+    opens: list[float] | None = None,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+    closes: list[float] | None = None,
+    volumes: list[float] | None = None,
+) -> pl.DataFrame:
+    """Build a minimal valid OHLCV DataFrame with Float64 epoch-second timestamps."""
+    n = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(timestamps, dtype=pl.Float64),
+            "open": pl.Series(opens if opens is not None else [100.0] * n, dtype=pl.Float64),
+            "high": pl.Series(highs if highs is not None else [110.0] * n, dtype=pl.Float64),
+            "low": pl.Series(lows if lows is not None else [90.0] * n, dtype=pl.Float64),
+            "close": pl.Series(closes if closes is not None else [105.0] * n, dtype=pl.Float64),
+            "volume": pl.Series(volumes if volumes is not None else [1000.0] * n, dtype=pl.Float64),
+        }
+    )
+
+
+# ===========================================================================
+# check_duplicate_timestamps
+# ===========================================================================
+
+
+class TestCheckDuplicateTimestamps:
+    def test_clean_dataframe_returns_empty(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY])
+        assert check_duplicate_timestamps(df) == []
+
+    def test_empty_dataframe_returns_empty(self) -> None:
+        df = _make_df([])
+        assert check_duplicate_timestamps(df) == []
+
+    def test_single_row_returns_empty(self) -> None:
+        df = _make_df([_BASE_TS])
+        assert check_duplicate_timestamps(df) == []
+
+    def test_single_duplicate_pair(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS, _BASE_TS + _DAY])
+        violations = check_duplicate_timestamps(df)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.check == ViolationType.DUPLICATE_TIMESTAMP
+        assert v.severity == "ERROR"
+        assert sorted(v.affected_rows) == [0, 1]
+        assert v.context["count"] == 2
+
+    def test_two_duplicate_groups(self) -> None:
+        ts_a = _BASE_TS
+        ts_b = _BASE_TS + _DAY
+        ts_c = _BASE_TS + 2 * _DAY
+        df = _make_df([ts_a, ts_a, ts_b, ts_b, ts_c])
+        violations = check_duplicate_timestamps(df)
+        assert len(violations) == 2
+        # sorted by first affected row
+        assert violations[0].affected_rows[0] < violations[1].affected_rows[0]
+
+    def test_triple_duplicate(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS, _BASE_TS, _BASE_TS + _DAY])
+        violations = check_duplicate_timestamps(df)
+        assert len(violations) == 1
+        assert violations[0].context["count"] == 3
+        assert len(violations[0].affected_rows) == 3
+
+    def test_violation_context_has_required_keys(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS])
+        v = check_duplicate_timestamps(df)[0]
+        assert "duplicate_timestamp" in v.context
+        assert "count" in v.context
+
+    def test_violations_sorted_by_first_affected_row(self) -> None:
+        # group at rows 2,3 should come after group at rows 0,1
+        df = _make_df([_BASE_TS, _BASE_TS, _BASE_TS + _DAY, _BASE_TS + _DAY])
+        violations = check_duplicate_timestamps(df)
+        assert len(violations) == 2
+        assert violations[0].affected_rows[0] == 0
+        assert violations[1].affected_rows[0] == 2
+
+
+# ===========================================================================
+# check_monotonic_timestamps
+# ===========================================================================
+
+
+class TestCheckMonotonicTimestamps:
+    def test_strictly_increasing_returns_empty(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY])
+        assert check_monotonic_timestamps(df) == []
+
+    def test_empty_dataframe_returns_empty(self) -> None:
+        assert check_monotonic_timestamps(_make_df([])) == []
+
+    def test_single_row_returns_empty(self) -> None:
+        assert check_monotonic_timestamps(_make_df([_BASE_TS])) == []
+
+    def test_two_equal_timestamps(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS])
+        violations = check_monotonic_timestamps(df)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.check == ViolationType.NON_MONOTONIC_TIMESTAMP
+        assert v.severity == "ERROR"
+        assert v.affected_rows == [0, 1]
+
+    def test_out_of_order_pair(self) -> None:
+        df = _make_df([_BASE_TS + _DAY, _BASE_TS])
+        violations = check_monotonic_timestamps(df)
+        assert len(violations) == 1
+        assert violations[0].affected_rows == [0, 1]
+
+    def test_multiple_out_of_order_pairs(self) -> None:
+        # timestamps go: 3, 2, 1 — two violations
+        df = _make_df([_BASE_TS + 2 * _DAY, _BASE_TS + _DAY, _BASE_TS])
+        violations = check_monotonic_timestamps(df)
+        assert len(violations) == 2
+
+    def test_violation_context_keys(self) -> None:
+        df = _make_df([_BASE_TS + _DAY, _BASE_TS])
+        v = check_monotonic_timestamps(df)[0]
+        assert "prev_timestamp" in v.context
+        assert "curr_timestamp" in v.context
+
+    def test_middle_out_of_order(self) -> None:
+        # valid, invalid, valid
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY, _BASE_TS])
+        violations = check_monotonic_timestamps(df)
+        assert len(violations) == 1
+        assert violations[0].affected_rows == [1, 2]
+
+
+# ===========================================================================
+# check_ohlc_consistency
+# ===========================================================================
+
+
+class TestCheckOhlcConsistency:
+    def test_valid_bars_returns_empty(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS, _BASE_TS + _DAY],
+            opens=[100.0, 200.0],
+            highs=[110.0, 210.0],
+            lows=[90.0, 190.0],
+            closes=[105.0, 205.0],
+        )
+        assert check_ohlc_consistency(df) == []
+
+    def test_empty_dataframe_returns_empty(self) -> None:
+        assert check_ohlc_consistency(_make_df([])) == []
+
+    def test_open_above_high(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[120.0],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[105.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.check == ViolationType.OHLC_INCONSISTENCY
+        assert v.severity == "ERROR"
+        assert v.affected_rows == [0]
+        assert "violated_constraint" in v.context
+
+    def test_open_below_low(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[80.0],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[105.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 1
+
+    def test_close_above_high(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[100.0],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[120.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 1
+
+    def test_close_below_low(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[100.0],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[80.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 1
+
+    def test_nan_in_open(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[float("nan")],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[105.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 1
+        constraint = violations[0].context.get("violated_constraint")
+        assert isinstance(constraint, str)
+        assert "NaN or null" in constraint
+
+    def test_multiple_bad_bars(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY],
+            opens=[120.0, 100.0, 120.0],
+            highs=[110.0, 110.0, 110.0],
+            lows=[90.0, 90.0, 90.0],
+            closes=[105.0, 105.0, 105.0],
+        )
+        violations = check_ohlc_consistency(df)
+        assert len(violations) == 2
+        assert violations[0].affected_rows == [0]
+        assert violations[1].affected_rows == [2]
+
+    def test_violation_context_has_ohlc_keys(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[120.0],
+            highs=[110.0],
+            lows=[90.0],
+            closes=[105.0],
+        )
+        ctx = check_ohlc_consistency(df)[0].context
+        assert "open" in ctx
+        assert "high" in ctx
+        assert "low" in ctx
+        assert "close" in ctx
+        assert "violated_constraint" in ctx
+
+    def test_doji_candle_all_equal_is_valid(self) -> None:
+        # open == close == high == low — valid
+        df = _make_df(
+            timestamps=[_BASE_TS],
+            opens=[100.0],
+            highs=[100.0],
+            lows=[100.0],
+            closes=[100.0],
+        )
+        assert check_ohlc_consistency(df) == []
+
+
+# ===========================================================================
+# check_volume_non_negative
+# ===========================================================================
+
+
+class TestCheckVolumeNonNegative:
+    def test_valid_volumes_returns_empty(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY], volumes=[1000.0, 2000.0])
+        assert check_volume_non_negative(df) == []
+
+    def test_zero_volume_is_valid(self) -> None:
+        df = _make_df([_BASE_TS], volumes=[0.0])
+        assert check_volume_non_negative(df) == []
+
+    def test_empty_dataframe_returns_empty(self) -> None:
+        assert check_volume_non_negative(_make_df([])) == []
+
+    def test_negative_volume(self) -> None:
+        df = _make_df([_BASE_TS], volumes=[-1.0])
+        violations = check_volume_non_negative(df)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.check == ViolationType.NEGATIVE_VOLUME
+        assert v.severity == "ERROR"
+        assert v.affected_rows == [0]
+        assert v.context["volume"] == -1.0
+
+    def test_nan_volume_context_is_none(self) -> None:
+        df = _make_df([_BASE_TS], volumes=[float("nan")])
+        violations = check_volume_non_negative(df)
+        assert len(violations) == 1
+        assert violations[0].context["volume"] is None
+
+    def test_multiple_negative_volumes(self) -> None:
+        df = _make_df(
+            [_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY],
+            volumes=[-5.0, 1000.0, -10.0],
+        )
+        violations = check_volume_non_negative(df)
+        assert len(violations) == 2
+        assert violations[0].affected_rows == [0]
+        assert violations[1].affected_rows == [2]
+
+    def test_mixed_nan_and_negative(self) -> None:
+        df = _make_df(
+            [_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY],
+            volumes=[float("nan"), 1000.0, -1.0],
+        )
+        violations = check_volume_non_negative(df)
+        assert len(violations) == 2
+
+
+# ===========================================================================
+# check_gaps
+# ===========================================================================
+
+
+class TestCheckGaps:
+    # -----------------------------------------------------------------------
+    # Happy path — no gaps
+    # -----------------------------------------------------------------------
+
+    def test_exact_cadence_1d_returns_empty(self) -> None:
+        ts = [_BASE_TS + i * _DAY for i in range(5)]
+        df = _make_df(ts)
+        assert check_gaps(df, "1D") == []
+
+    def test_exact_cadence_1h_returns_empty(self) -> None:
+        hour = 3600
+        ts = [_BASE_TS + i * hour for i in range(10)]
+        df = _make_df(ts)
+        assert check_gaps(df, "1H") == []
+
+    def test_exact_cadence_1min_returns_empty(self) -> None:
+        ts = [_BASE_TS + i * 60 for i in range(10)]
+        df = _make_df(ts)
+        assert check_gaps(df, "1") == []
+
+    def test_exact_cadence_15s_returns_empty(self) -> None:
+        ts = [_BASE_TS + i * 15 for i in range(10)]
+        df = _make_df(ts)
+        assert check_gaps(df, "15S") == []
+
+    # -----------------------------------------------------------------------
+    # Edge cases — 0 or 1 rows
+    # -----------------------------------------------------------------------
+
+    def test_empty_dataframe_returns_empty(self) -> None:
+        assert check_gaps(_make_df([]), "1D") == []
+
+    def test_single_row_returns_empty(self) -> None:
+        assert check_gaps(_make_df([_BASE_TS]), "1D") == []
+
+    def test_two_rows_exact_cadence_returns_empty(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY])
+        assert check_gaps(df, "1D") == []
+
+    # -----------------------------------------------------------------------
+    # Single gap
+    # -----------------------------------------------------------------------
+
+    def test_single_gap_detected(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 2 * _DAY]  # missing one day
+        df = _make_df(ts)
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.check == ViolationType.GAP_DETECTED
+        assert v.severity == "WARNING"
+        assert v.affected_rows == [1]
+
+    def test_single_gap_in_middle(self) -> None:
+        ts = [
+            _BASE_TS,
+            _BASE_TS + _DAY,
+            _BASE_TS + 3 * _DAY,  # gap here
+            _BASE_TS + 4 * _DAY,
+        ]
+        df = _make_df(ts)
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+        assert violations[0].affected_rows == [2]
+
+    # -----------------------------------------------------------------------
+    # Multiple gaps
+    # -----------------------------------------------------------------------
+
+    def test_multiple_gaps(self) -> None:
+        ts = [
+            _BASE_TS,
+            _BASE_TS + 2 * _DAY,  # gap → row 1
+            _BASE_TS + 3 * _DAY,
+            _BASE_TS + 5 * _DAY,  # gap → row 3
+        ]
+        df = _make_df(ts)
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 2
+        assert violations[0].affected_rows == [1]
+        assert violations[1].affected_rows == [3]
+
+    # -----------------------------------------------------------------------
+    # Sub-interval spacing: actual < expected — must NOT be flagged
+    # (gap detection only flags missing bars, not closer-than-expected spacing)
+    # -----------------------------------------------------------------------
+
+    def test_sub_interval_spacing_no_violation(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 3600]  # 1 hour apart, interval is 1D
+        df = _make_df(ts)
+        # actual (3600s) < expected (86400s) — not a gap
+        assert check_gaps(df, "1D") == []
+
+    def test_sub_interval_5min_interval_3min_apart(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 180]  # 3 min < 5 min expected
+        df = _make_df(ts)
+        assert check_gaps(df, "5") == []
+
+    # -----------------------------------------------------------------------
+    # Violation context
+    # -----------------------------------------------------------------------
+
+    def test_violation_context_keys(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + 2 * _DAY])
+        v = check_gaps(df, "1D")[0]
+        assert v.context["expected_interval"] == "1D"
+        assert v.context["actual_gap"] == f"{2 * _DAY}s"
+        assert "prev_timestamp" in v.context
+        assert "curr_timestamp" in v.context
+
+    def test_violation_message_includes_seconds(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + 2 * _DAY])
+        v = check_gaps(df, "1D")[0]
+        assert f"expected {_DAY}s" in v.message
+        assert f"got {2 * _DAY}s" in v.message
+
+    # -----------------------------------------------------------------------
+    # Calendar gap (weekend) — still flagged as WARNING (cadence-only)
+    # -----------------------------------------------------------------------
+
+    def test_weekend_gap_flagged_for_daily_interval(self) -> None:
+        """Friday → Monday produces a 3-day gap; cadence-only, no calendar awareness."""
+        friday_ts = 1700179200.0  # 2023-11-17 00:00:00 UTC (Friday)
+        monday_ts = friday_ts + 3 * _DAY
+        df = _make_df([friday_ts, monday_ts])
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+        assert violations[0].severity == "WARNING"
+        assert violations[0].context["actual_gap"] == f"{3 * _DAY}s"
+
+    def test_two_day_gap_flagged(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 2 * _DAY]
+        df = _make_df(ts)
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+
+    # -----------------------------------------------------------------------
+    # Multiple interval types
+    # -----------------------------------------------------------------------
+
+    def test_1h_interval_gap(self) -> None:
+        hour = 3600
+        ts = [_BASE_TS, _BASE_TS + 2 * hour]  # 2 hours, expected 1
+        df = _make_df(ts)
+        violations = check_gaps(df, "1H")
+        assert len(violations) == 1
+        assert violations[0].context["actual_gap"] == f"{2 * hour}s"
+
+    def test_15_minute_interval_gap(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 1800]  # 30 min, expected 15 min
+        df = _make_df(ts)
+        violations = check_gaps(df, "15")
+        assert len(violations) == 1
+
+    def test_1s_interval_gap(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 5]  # 5 sec, expected 1 sec
+        df = _make_df(ts)
+        violations = check_gaps(df, "1S")
+        assert len(violations) == 1
+
+    def test_3d_interval_exact_cadence(self) -> None:
+        ts = [_BASE_TS + i * 3 * _DAY for i in range(4)]
+        df = _make_df(ts)
+        assert check_gaps(df, "3D") == []
+
+    # -----------------------------------------------------------------------
+    # Timestamp dtype support
+    # -----------------------------------------------------------------------
+
+    def test_int64_epoch_seconds_exact_cadence(self) -> None:
+        ts_int = [int(_BASE_TS) + i * _DAY for i in range(3)]
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(ts_int, dtype=pl.Int64),
+                "open": [100.0, 100.0, 100.0],
+                "high": [110.0, 110.0, 110.0],
+                "low": [90.0, 90.0, 90.0],
+                "close": [105.0, 105.0, 105.0],
+                "volume": [1000.0, 1000.0, 1000.0],
+            }
+        )
+        assert check_gaps(df, "1D") == []
+
+    def test_int64_epoch_seconds_gap_detected(self) -> None:
+        ts_int = [int(_BASE_TS), int(_BASE_TS) + 2 * _DAY]
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(ts_int, dtype=pl.Int64),
+                "open": [100.0, 100.0],
+                "high": [110.0, 110.0],
+                "low": [90.0, 90.0],
+                "close": [105.0, 105.0],
+                "volume": [1000.0, 1000.0],
+            }
+        )
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+
+    def test_date_dtype_exact_cadence(self) -> None:
+        dates = [date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)]
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(dates, dtype=pl.Date),
+                "open": [100.0, 100.0, 100.0],
+                "high": [110.0, 110.0, 110.0],
+                "low": [90.0, 90.0, 90.0],
+                "close": [105.0, 105.0, 105.0],
+                "volume": [1000.0, 1000.0, 1000.0],
+            }
+        )
+        assert check_gaps(df, "1D") == []
+
+    def test_date_dtype_gap_detected(self) -> None:
+        dates = [date(2024, 1, 1), date(2024, 1, 3)]  # missing Jan 2
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(dates, dtype=pl.Date),
+                "open": [100.0, 100.0],
+                "high": [110.0, 110.0],
+                "low": [90.0, 90.0],
+                "close": [105.0, 105.0],
+                "volume": [1000.0, 1000.0],
+            }
+        )
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+
+    def test_datetime_dtype_exact_cadence(self) -> None:
+        base = datetime(2024, 1, 1, tzinfo=UTC)
+        dts = [base + timedelta(days=i) for i in range(4)]
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(dts),
+                "open": [100.0] * 4,
+                "high": [110.0] * 4,
+                "low": [90.0] * 4,
+                "close": [105.0] * 4,
+                "volume": [1000.0] * 4,
+            }
+        )
+        assert check_gaps(df, "1D") == []
+
+    def test_datetime_dtype_gap_detected(self) -> None:
+        base = datetime(2024, 1, 1, tzinfo=UTC)
+        dts = [base, base + timedelta(days=2)]  # 1-day gap
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(dts),
+                "open": [100.0, 100.0],
+                "high": [110.0, 110.0],
+                "low": [90.0, 90.0],
+                "close": [105.0, 105.0],
+                "volume": [1000.0, 1000.0],
+            }
+        )
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 1
+
+    # -----------------------------------------------------------------------
+    # Error conditions
+    #
+    # Weekly and monthly intervals raise ValueError because interval_to_seconds()
+    # does not support variable-cadence intervals. This is by design — a
+    # cadence-based gap check has no meaningful interpretation for intervals
+    # whose duration varies (e.g., February vs March for monthly).
+    # -----------------------------------------------------------------------
+
+    def test_invalid_interval_raises_value_error(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "invalid_interval")
+
+    def test_empty_interval_raises_value_error(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "")
+
+    def test_weekly_interval_raises_value_error(self) -> None:
+        """Weekly intervals have variable durations and cannot be used for cadence gaps."""
+        df = _make_df([_BASE_TS, _BASE_TS + 7 * _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "1W")
+
+    def test_bare_weekly_interval_raises_value_error(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + 7 * _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "W")
+
+    def test_monthly_interval_raises_value_error(self) -> None:
+        """Monthly intervals have variable durations and cannot be used for cadence gaps."""
+        df = _make_df([_BASE_TS, _BASE_TS + 30 * _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "1M")
+
+    def test_bare_monthly_interval_raises_value_error(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + 30 * _DAY])
+        with pytest.raises(ValueError):
+            check_gaps(df, "M")
+
+    def test_non_string_interval_raises_type_error(self) -> None:
+        df = _make_df([_BASE_TS, _BASE_TS + _DAY])
+        with pytest.raises(TypeError):
+            check_gaps(df, 86400)  # type: ignore[arg-type]
+
+    # -----------------------------------------------------------------------
+    # Determinism — violations in row order
+    # -----------------------------------------------------------------------
+
+    def test_violations_in_row_order(self) -> None:
+        ts = [
+            _BASE_TS,
+            _BASE_TS + 3 * _DAY,  # gap at row 1
+            _BASE_TS + 4 * _DAY,
+            _BASE_TS + 6 * _DAY,  # gap at row 3
+            _BASE_TS + 7 * _DAY,
+        ]
+        df = _make_df(ts)
+        violations = check_gaps(df, "1D")
+        assert len(violations) == 2
+        assert violations[0].affected_rows == [1]
+        assert violations[1].affected_rows == [3]
+
+    # -----------------------------------------------------------------------
+    # Non-destructive — input DataFrame is not mutated
+    # -----------------------------------------------------------------------
+
+    def test_input_dataframe_not_mutated(self) -> None:
+        ts = [_BASE_TS, _BASE_TS + 2 * _DAY]
+        df = _make_df(ts)
+        original_shape = df.shape
+        original_first_ts = df["timestamp"][0]
+        check_gaps(df, "1D")
+        assert df.shape == original_shape
+        assert df["timestamp"][0] == original_first_ts

--- a/tests/test_validation_composite.py
+++ b/tests/test_validation_composite.py
@@ -3,8 +3,538 @@ Integration tests for tvkit.validation.validate_ohlcv() composite validator.
 
 Tests for:
 - validate_ohlcv() orchestration and deterministic check ordering
-- Schema validation (_require_ohlcv_schema)
-- selective checks via the checks= parameter
+- Schema validation (_require_ohlcv_schema via validate_ohlcv)
+- Selective checks via the checks= parameter
 - Gap detection skip/raise behaviour based on interval and checks arguments
 - ValidationResult.is_valid flag, errors, warnings properties
 """
+
+from datetime import UTC, date, datetime
+
+import polars as pl
+import pytest
+
+from tvkit.validation import (
+    ValidationResult,
+    Violation,
+    ViolationType,
+    validate_ohlcv,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_TS = 1_700_000_000.0  # 2023-11-14 22:13:20 UTC (Float64 epoch seconds)
+_DAY = 86_400.0
+_HOUR = 3_600.0
+
+
+def _make_df(
+    timestamps: list[float] | None = None,
+    opens: list[float] | None = None,
+    highs: list[float] | None = None,
+    lows: list[float] | None = None,
+    closes: list[float] | None = None,
+    volumes: list[float] | None = None,
+    n: int = 3,
+    ts_dtype: pl.DataType = pl.Float64,
+) -> pl.DataFrame:
+    """Build a valid OHLCV DataFrame with clean data by default."""
+    if timestamps is None:
+        timestamps = [_BASE_TS + i * _DAY for i in range(n)]
+    n = len(timestamps)
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(timestamps, dtype=ts_dtype),
+            "open": pl.Series(opens if opens is not None else [100.0] * n, dtype=pl.Float64),
+            "high": pl.Series(highs if highs is not None else [110.0] * n, dtype=pl.Float64),
+            "low": pl.Series(lows if lows is not None else [90.0] * n, dtype=pl.Float64),
+            "close": pl.Series(closes if closes is not None else [105.0] * n, dtype=pl.Float64),
+            "volume": pl.Series(volumes if volumes is not None else [1000.0] * n, dtype=pl.Float64),
+        }
+    )
+
+
+def _make_datetime_df(n: int = 3) -> pl.DataFrame:
+    """Build a valid OHLCV DataFrame with Datetime timestamps."""
+    base = datetime(2023, 11, 14, tzinfo=UTC)
+    from datetime import timedelta
+
+    timestamps = [base + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(timestamps).cast(pl.Datetime("us", "UTC")),
+            "open": pl.Series([100.0] * n, dtype=pl.Float64),
+            "high": pl.Series([110.0] * n, dtype=pl.Float64),
+            "low": pl.Series([90.0] * n, dtype=pl.Float64),
+            "close": pl.Series([105.0] * n, dtype=pl.Float64),
+            "volume": pl.Series([1000.0] * n, dtype=pl.Float64),
+        }
+    )
+
+
+def _make_date_df(n: int = 3) -> pl.DataFrame:
+    """Build a valid OHLCV DataFrame with Date timestamps."""
+    from datetime import timedelta
+
+    base = date(2023, 11, 14)
+    timestamps = [base + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": pl.Series(timestamps, dtype=pl.Date),
+            "open": pl.Series([100.0] * n, dtype=pl.Float64),
+            "high": pl.Series([110.0] * n, dtype=pl.Float64),
+            "low": pl.Series([90.0] * n, dtype=pl.Float64),
+            "close": pl.Series([105.0] * n, dtype=pl.Float64),
+            "volume": pl.Series([1000.0] * n, dtype=pl.Float64),
+        }
+    )
+
+
+# ===========================================================================
+# Schema Validation Tests
+# ===========================================================================
+
+
+class TestSchemaValidation:
+    def test_missing_timestamp_raises(self) -> None:
+        df = pl.DataFrame(
+            {
+                "open": [100.0],
+                "high": [110.0],
+                "low": [90.0],
+                "close": [105.0],
+                "volume": [1000.0],
+            }
+        )
+        with pytest.raises(ValueError, match="timestamp"):
+            validate_ohlcv(df)
+
+    def test_missing_open_raises(self) -> None:
+        df = _make_df()
+        df = df.drop("open")
+        with pytest.raises(ValueError, match="open"):
+            validate_ohlcv(df)
+
+    def test_missing_high_raises(self) -> None:
+        df = _make_df()
+        df = df.drop("high")
+        with pytest.raises(ValueError, match="high"):
+            validate_ohlcv(df)
+
+    def test_missing_low_raises(self) -> None:
+        df = _make_df()
+        df = df.drop("low")
+        with pytest.raises(ValueError, match="low"):
+            validate_ohlcv(df)
+
+    def test_missing_close_raises(self) -> None:
+        df = _make_df()
+        df = df.drop("close")
+        with pytest.raises(ValueError, match="close"):
+            validate_ohlcv(df)
+
+    def test_missing_volume_raises(self) -> None:
+        df = _make_df()
+        df = df.drop("volume")
+        with pytest.raises(ValueError, match="volume"):
+            validate_ohlcv(df)
+
+    def test_wrong_dtype_on_open_raises(self) -> None:
+        df = _make_df()
+        df = df.with_columns(pl.col("open").cast(pl.Utf8))
+        with pytest.raises(ValueError, match="open"):
+            validate_ohlcv(df)
+
+    def test_wrong_dtype_on_volume_raises(self) -> None:
+        df = _make_df()
+        df = df.with_columns(pl.col("volume").cast(pl.Utf8))
+        with pytest.raises(ValueError, match="volume"):
+            validate_ohlcv(df)
+
+    def test_wrong_dtype_on_timestamp_raises(self) -> None:
+        df = _make_df()
+        df = df.with_columns(pl.col("timestamp").cast(pl.Utf8))
+        with pytest.raises(ValueError, match="timestamp"):
+            validate_ohlcv(df)
+
+    def test_empty_dataframe_passes_schema(self) -> None:
+        df = _make_df(n=0)
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+        assert result.violations == []
+        assert result.bars_checked == 0
+
+    def test_float64_timestamp_accepted(self) -> None:
+        df = _make_df(ts_dtype=pl.Float64)
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+    def test_int64_timestamp_accepted(self) -> None:
+        base_int = int(_BASE_TS)
+        df = _make_df(
+            timestamps=[float(base_int + i * int(_DAY)) for i in range(3)],
+            ts_dtype=pl.Float64,
+        )
+        df = df.with_columns(pl.col("timestamp").cast(pl.Int64))
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+    def test_datetime_timestamp_accepted(self) -> None:
+        df = _make_datetime_df()
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+    def test_date_timestamp_accepted(self) -> None:
+        df = _make_date_df()
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+    def test_float32_prices_accepted(self) -> None:
+        df = _make_df()
+        df = df.with_columns(
+            pl.col("open").cast(pl.Float32),
+            pl.col("high").cast(pl.Float32),
+            pl.col("low").cast(pl.Float32),
+            pl.col("close").cast(pl.Float32),
+        )
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+    def test_int64_volume_accepted(self) -> None:
+        df = _make_df()
+        df = df.with_columns(pl.col("volume").cast(pl.Int64))
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+
+
+# ===========================================================================
+# Core Orchestration Tests
+# ===========================================================================
+
+
+class TestValidateOhlcvOrchestration:
+    def test_clean_data_is_valid(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df)
+        assert result.is_valid is True
+        assert result.violations == []
+
+    def test_bars_checked_equals_row_count(self) -> None:
+        df = _make_df(n=5)
+        result = validate_ohlcv(df)
+        assert result.bars_checked == 5
+
+    def test_bars_checked_zero_for_empty_df(self) -> None:
+        df = _make_df(n=0)
+        result = validate_ohlcv(df)
+        assert result.bars_checked == 0
+
+    def test_checks_run_without_interval_excludes_gap(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df)
+        assert ViolationType.GAP_DETECTED not in result.checks_run
+        assert ViolationType.DUPLICATE_TIMESTAMP in result.checks_run
+        assert ViolationType.NON_MONOTONIC_TIMESTAMP in result.checks_run
+        assert ViolationType.OHLC_INCONSISTENCY in result.checks_run
+        assert ViolationType.NEGATIVE_VOLUME in result.checks_run
+
+    def test_checks_run_with_interval_includes_gap(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df, interval="1D")
+        assert ViolationType.GAP_DETECTED in result.checks_run
+
+    def test_checks_run_order_is_deterministic(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df, interval="1D")
+        expected_order = [
+            ViolationType.DUPLICATE_TIMESTAMP,
+            ViolationType.NON_MONOTONIC_TIMESTAMP,
+            ViolationType.OHLC_INCONSISTENCY,
+            ViolationType.NEGATIVE_VOLUME,
+            ViolationType.GAP_DETECTED,
+        ]
+        assert result.checks_run == expected_order
+
+    def test_error_violation_sets_is_valid_false(self) -> None:
+        # Duplicate timestamps cause ERROR violation
+        ts = _BASE_TS
+        df = _make_df(timestamps=[ts, ts, ts + _DAY])
+        result = validate_ohlcv(df)
+        assert result.is_valid is False
+
+    def test_warning_violation_leaves_is_valid_true(self) -> None:
+        # Weekend gap for daily interval: Friday → Monday (3-day span > 1-day expected)
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY  # skip weekend
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        assert result.is_valid is True
+        assert len(result.warnings) == 1
+        assert result.warnings[0].check == ViolationType.GAP_DETECTED
+
+    def test_mixed_error_and_warning_is_valid_false(self) -> None:
+        # Duplicate timestamps (ERROR) + gap (WARNING)
+        ts = _BASE_TS
+        friday = ts + 10 * _DAY
+        monday = friday + 3 * _DAY  # gap
+        # Duplicate appears before the gap data
+        df = _make_df(timestamps=[ts, ts, ts + _DAY, friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        assert result.is_valid is False
+        assert len(result.errors) >= 1
+        assert len(result.warnings) >= 1
+
+    def test_returns_validation_result_type(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df)
+        assert isinstance(result, ValidationResult)
+
+    def test_violations_are_violation_instances(self) -> None:
+        ts = _BASE_TS
+        df = _make_df(timestamps=[ts, ts])
+        result = validate_ohlcv(df)
+        assert all(isinstance(v, Violation) for v in result.violations)
+
+
+# ===========================================================================
+# Gap Detection Behavior Tests
+# ===========================================================================
+
+
+class TestValidateOhlcvGapDetection:
+    def test_no_interval_gap_detection_silently_skipped(self) -> None:
+        # Even with obvious gaps, no gap violations without interval
+        df = _make_df(timestamps=[_BASE_TS, _BASE_TS + 100 * _DAY])
+        result = validate_ohlcv(df)
+        gap_violations = [v for v in result.violations if v.check == ViolationType.GAP_DETECTED]
+        assert gap_violations == []
+        assert ViolationType.GAP_DETECTED not in result.checks_run
+
+    def test_with_interval_gap_violations_reported(self) -> None:
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        gap_violations = [v for v in result.violations if v.check == ViolationType.GAP_DETECTED]
+        assert len(gap_violations) == 1
+        assert gap_violations[0].severity == "WARNING"
+
+    def test_explicit_gap_detected_without_interval_raises(self) -> None:
+        df = _make_df()
+        with pytest.raises(ValueError, match="interval"):
+            validate_ohlcv(df, checks=[ViolationType.GAP_DETECTED])
+
+    def test_explicit_gap_detected_with_interval_runs(self) -> None:
+        df = _make_df(timestamps=[_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY])
+        result = validate_ohlcv(df, interval="1D", checks=[ViolationType.GAP_DETECTED])
+        assert ViolationType.GAP_DETECTED in result.checks_run
+        assert result.violations == []  # exact cadence, no gaps
+
+    def test_gap_detection_exact_cadence_no_violations(self) -> None:
+        df = _make_df(
+            timestamps=[_BASE_TS + i * _HOUR for i in range(5)],
+        )
+        result = validate_ohlcv(df, interval="1H")
+        gap_violations = [v for v in result.violations if v.check == ViolationType.GAP_DETECTED]
+        assert gap_violations == []
+
+    def test_gap_detection_sub_interval_spacing_no_violation(self) -> None:
+        # Bars closer than expected — not a gap
+        df = _make_df(
+            timestamps=[_BASE_TS, _BASE_TS + _HOUR / 2],
+        )
+        result = validate_ohlcv(df, interval="1H")
+        gap_violations = [v for v in result.violations if v.check == ViolationType.GAP_DETECTED]
+        assert gap_violations == []
+
+
+# ===========================================================================
+# Selective Checks Tests
+# ===========================================================================
+
+
+class TestValidateOhlcvSelectiveChecks:
+    def test_single_check_requested_only_that_runs(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df, checks=[ViolationType.DUPLICATE_TIMESTAMP])
+        assert result.checks_run == [ViolationType.DUPLICATE_TIMESTAMP]
+
+    def test_single_check_does_not_report_other_violations(self) -> None:
+        # OHLC violation present — but we only request duplicate check
+        df = _make_df(opens=[200.0, 100.0, 100.0])  # open > high (110) — OHLC error
+        result = validate_ohlcv(df, checks=[ViolationType.DUPLICATE_TIMESTAMP])
+        # No OHLC violation reported since OHLC check not requested
+        ohlc_violations = [
+            v for v in result.violations if v.check == ViolationType.OHLC_INCONSISTENCY
+        ]
+        assert ohlc_violations == []
+        # Result should be valid (no duplicate timestamps)
+        assert result.is_valid is True
+
+    def test_multiple_checks_run_in_deterministic_order(self) -> None:
+        df = _make_df()
+        # Request in reversed order
+        checks = [ViolationType.NEGATIVE_VOLUME, ViolationType.DUPLICATE_TIMESTAMP]
+        result = validate_ohlcv(df, checks=checks)
+        # Execution order must follow _CHECK_ORDER regardless of request order
+        assert result.checks_run == [
+            ViolationType.DUPLICATE_TIMESTAMP,
+            ViolationType.NEGATIVE_VOLUME,
+        ]
+
+    def test_unknown_check_type_raises(self) -> None:
+        df = _make_df()
+        with pytest.raises(ValueError, match="Unknown check type"):
+            validate_ohlcv(df, checks=["not_a_real_check"])  # type: ignore[list-item]
+
+    def test_empty_checks_list_returns_no_violations(self) -> None:
+        df = _make_df(timestamps=[_BASE_TS, _BASE_TS])  # would cause duplicate error
+        result = validate_ohlcv(df, checks=[])
+        assert result.violations == []
+        assert result.checks_run == []
+        assert result.is_valid is True
+
+    def test_all_checks_explicitly_run_with_interval(self) -> None:
+        df = _make_df()
+        all_checks = list(ViolationType)
+        result = validate_ohlcv(df, interval="1D", checks=all_checks)
+        assert set(result.checks_run) == set(ViolationType)
+
+    def test_selective_gap_check_with_interval_returns_violations(self) -> None:
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(
+            df,
+            interval="1D",
+            checks=[ViolationType.GAP_DETECTED],
+        )
+        assert len(result.violations) == 1
+        assert result.violations[0].check == ViolationType.GAP_DETECTED
+
+
+# ===========================================================================
+# Deterministic Ordering Tests
+# ===========================================================================
+
+
+class TestViolationOrdering:
+    def test_violations_ordered_by_check_type_then_row(self) -> None:
+        # Create a DataFrame with both a DUPLICATE_TIMESTAMP violation (row 0,1)
+        # and an OHLC violation (row 2)
+        ts = _BASE_TS
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series([ts, ts, ts + _DAY, ts + 2 * _DAY], dtype=pl.Float64),
+                "open": pl.Series(
+                    [100.0, 100.0, 200.0, 100.0], dtype=pl.Float64
+                ),  # row 2: open > high
+                "high": pl.Series([110.0, 110.0, 110.0, 110.0], dtype=pl.Float64),
+                "low": pl.Series([90.0, 90.0, 90.0, 90.0], dtype=pl.Float64),
+                "close": pl.Series([105.0, 105.0, 105.0, 105.0], dtype=pl.Float64),
+                "volume": pl.Series([1000.0, 1000.0, 1000.0, 1000.0], dtype=pl.Float64),
+            }
+        )
+        result = validate_ohlcv(df)
+
+        # Violations must be sorted: DUPLICATE_TIMESTAMP before OHLC_INCONSISTENCY
+        checks_in_order = [v.check for v in result.violations]
+        duplicate_idx = next(
+            i for i, c in enumerate(checks_in_order) if c == ViolationType.DUPLICATE_TIMESTAMP
+        )
+        ohlc_idx = next(
+            i for i, c in enumerate(checks_in_order) if c == ViolationType.OHLC_INCONSISTENCY
+        )
+        assert duplicate_idx < ohlc_idx
+
+    def test_violations_from_same_check_ordered_by_row(self) -> None:
+        # Two OHLC violations at rows 0 and 2 — must appear in row order
+        df = pl.DataFrame(
+            {
+                "timestamp": pl.Series(
+                    [_BASE_TS, _BASE_TS + _DAY, _BASE_TS + 2 * _DAY], dtype=pl.Float64
+                ),
+                "open": pl.Series(
+                    [200.0, 100.0, 200.0], dtype=pl.Float64
+                ),  # rows 0, 2: open > high
+                "high": pl.Series([110.0, 110.0, 110.0], dtype=pl.Float64),
+                "low": pl.Series([90.0, 90.0, 90.0], dtype=pl.Float64),
+                "close": pl.Series([105.0, 105.0, 105.0], dtype=pl.Float64),
+                "volume": pl.Series([1000.0, 1000.0, 1000.0], dtype=pl.Float64),
+            }
+        )
+        result = validate_ohlcv(df)
+        ohlc_violations = [
+            v for v in result.violations if v.check == ViolationType.OHLC_INCONSISTENCY
+        ]
+        assert len(ohlc_violations) == 2
+        assert ohlc_violations[0].affected_rows[0] < ohlc_violations[1].affected_rows[0]
+
+
+# ===========================================================================
+# ValidationResult Property Tests
+# ===========================================================================
+
+
+class TestValidationResultProperties:
+    def test_errors_returns_only_error_violations(self) -> None:
+        # Duplicate → ERROR; gap → WARNING
+        ts = _BASE_TS
+        friday = ts + 10 * _DAY
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[ts, ts, ts + _DAY, friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        for v in result.errors:
+            assert v.severity == "ERROR"
+
+    def test_warnings_returns_only_warning_violations(self) -> None:
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        for v in result.warnings:
+            assert v.severity == "WARNING"
+
+    def test_errors_empty_when_no_error_violations(self) -> None:
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        assert result.errors == []
+
+    def test_warnings_empty_when_no_warning_violations(self) -> None:
+        ts = _BASE_TS
+        df = _make_df(timestamps=[ts, ts])  # duplicate — ERROR only
+        result = validate_ohlcv(df)
+        assert result.warnings == []
+
+    def test_model_dump_excludes_errors_and_warnings(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df)
+        dumped = result.model_dump()
+        assert "errors" not in dumped
+        assert "warnings" not in dumped
+
+    def test_model_dump_includes_expected_keys(self) -> None:
+        df = _make_df()
+        result = validate_ohlcv(df)
+        dumped = result.model_dump()
+        assert set(dumped.keys()) == {"is_valid", "violations", "bars_checked", "checks_run"}
+
+    def test_errors_count_matches_is_valid_false(self) -> None:
+        ts = _BASE_TS
+        df = _make_df(timestamps=[ts, ts])
+        result = validate_ohlcv(df)
+        assert not result.is_valid
+        assert len(result.errors) > 0
+
+    def test_is_valid_true_when_only_warnings(self) -> None:
+        friday = _BASE_TS
+        monday = friday + 3 * _DAY
+        df = _make_df(timestamps=[friday, monday])
+        result = validate_ohlcv(df, interval="1D")
+        assert result.is_valid is True
+        assert len(result.warnings) > 0
+        assert len(result.errors) == 0

--- a/tests/test_validation_composite.py
+++ b/tests/test_validation_composite.py
@@ -1,0 +1,10 @@
+"""
+Integration tests for tvkit.validation.validate_ohlcv() composite validator.
+
+Tests for:
+- validate_ohlcv() orchestration and deterministic check ordering
+- Schema validation (_require_ohlcv_schema)
+- selective checks via the checks= parameter
+- Gap detection skip/raise behaviour based on interval and checks arguments
+- ValidationResult.is_valid flag, errors, warnings properties
+"""

--- a/tvkit/export/data_exporter.py
+++ b/tvkit/export/data_exporter.py
@@ -9,8 +9,11 @@ import logging
 from pathlib import Path
 from typing import Any, cast, overload
 
+import polars as pl
+
 from ..api.chart.models.ohlcv import OHLCVBar
 from ..api.scanner.models import StockData
+from ..validation import DataIntegrityError, ValidationResult, validate_ohlcv
 from .formatters import BaseFormatter, CSVFormatter, JSONFormatter, PolarsFormatter
 from .models import (
     ExportConfig,
@@ -208,6 +211,10 @@ class DataExporter:
         data: list[OHLCVBar] | list[StockData],
         file_path: Path | str,
         include_metadata: bool = True,
+        *,
+        validate: bool = False,
+        strict: bool = False,
+        interval: str | None = None,
         **json_options: Any,
     ) -> Path:
         """
@@ -217,10 +224,24 @@ class DataExporter:
             data: OHLCV bars or scanner data
             file_path: Output file path
             include_metadata: Whether to include metadata in JSON
+            validate: If True, run validate_ohlcv() before writing.
+                Violations are logged at WARNING level. Does not affect
+                export behavior unless strict=True. Only applies to OHLCV
+                data; scanner data silently skips validation.
+            strict: If True and validate=True, raise DataIntegrityError if
+                any ERROR-level violations are found. The file is NOT written.
+                WARNING-only results do not raise.
+            interval: Passed to validate_ohlcv() for gap detection.
+                Only relevant when validate=True.
             **json_options: Additional JSON formatting options
 
         Returns:
             Path to the created JSON file
+
+        Raises:
+            DataIntegrityError: If validate=True, strict=True, and ERROR
+                violations are found.
+            RuntimeError: If the export fails or produces no file path.
 
         Example:
             >>> exporter = DataExporter()
@@ -230,6 +251,9 @@ class DataExporter:
             ...     indent=4
             ... )
         """
+        if validate:
+            self._run_ohlcv_validation(data, strict=strict, interval=interval)
+
         config: ExportConfig = ExportConfig(
             format=ExportFormat.JSON,
             include_metadata=include_metadata,
@@ -264,6 +288,10 @@ class DataExporter:
         data: list[OHLCVBar] | list[StockData],
         file_path: Path | str,
         include_metadata: bool = True,
+        *,
+        validate: bool = False,
+        strict: bool = False,
+        interval: str | None = None,
         **csv_options: Any,
     ) -> Path:
         """
@@ -273,10 +301,24 @@ class DataExporter:
             data: OHLCV bars or scanner data
             file_path: Output file path
             include_metadata: Whether to include metadata file
+            validate: If True, run validate_ohlcv() before writing.
+                Violations are logged at WARNING level. Does not affect
+                export behavior unless strict=True. Only applies to OHLCV
+                data; scanner data silently skips validation.
+            strict: If True and validate=True, raise DataIntegrityError if
+                any ERROR-level violations are found. The file is NOT written.
+                WARNING-only results do not raise.
+            interval: Passed to validate_ohlcv() for gap detection.
+                Only relevant when validate=True.
             **csv_options: Additional CSV formatting options
 
         Returns:
             Path to the created CSV file
+
+        Raises:
+            DataIntegrityError: If validate=True, strict=True, and ERROR
+                violations are found.
+            RuntimeError: If the export fails or produces no file path.
 
         Example:
             >>> exporter = DataExporter()
@@ -287,6 +329,9 @@ class DataExporter:
             ...     timestamp_format="iso"
             ... )
         """
+        if validate:
+            self._run_ohlcv_validation(data, strict=strict, interval=interval)
+
         config: ExportConfig = ExportConfig(
             format=ExportFormat.CSV,
             include_metadata=include_metadata,
@@ -315,6 +360,55 @@ class DataExporter:
             raise RuntimeError("Export did not produce a file path")
 
         return result.file_path
+
+    def _run_ohlcv_validation(
+        self,
+        data: list[OHLCVBar] | list[StockData],
+        *,
+        strict: bool,
+        interval: str | None,
+    ) -> None:
+        """
+        Run OHLCV data integrity validation if data contains OHLCV bars.
+
+        Silently skips validation for scanner (StockData) inputs and empty lists.
+        Logs all violations at WARNING level using structured extra fields.
+        Raises DataIntegrityError only when strict=True and ERROR-level violations
+        are found. WARNING-only results never raise.
+
+        Args:
+            data: OHLCV bars or scanner data. Validation applies to OHLCVBar only.
+            strict: If True, raise DataIntegrityError on ERROR violations.
+            interval: Passed to validate_ohlcv() for gap detection.
+
+        Raises:
+            DataIntegrityError: If strict=True and ERROR-level violations are found.
+        """
+        if not data or not isinstance(data[0], OHLCVBar):
+            return
+
+        ohlcv_bars: list[OHLCVBar] = cast(list[OHLCVBar], data)
+        df: pl.DataFrame = pl.DataFrame(
+            {
+                "timestamp": [bar.timestamp for bar in ohlcv_bars],
+                "open": [bar.open for bar in ohlcv_bars],
+                "high": [bar.high for bar in ohlcv_bars],
+                "low": [bar.low for bar in ohlcv_bars],
+                "close": [bar.close for bar in ohlcv_bars],
+                "volume": [bar.volume for bar in ohlcv_bars],
+            }
+        )
+
+        result: ValidationResult = validate_ohlcv(df, interval=interval)
+
+        for violation in result.violations:
+            logger.warning(
+                violation.message,
+                extra={"check": violation.check.value, "rows": violation.affected_rows},
+            )
+
+        if strict and result.errors:
+            raise DataIntegrityError(result)
 
     def add_formatter(
         self, format_type: ExportFormat, formatter_class: type[BaseFormatter]

--- a/tvkit/validation/__init__.py
+++ b/tvkit/validation/__init__.py
@@ -1,0 +1,46 @@
+"""
+tvkit.validation — OHLCV data integrity validation.
+
+Provides utilities to verify the structural and logical consistency of OHLCV
+bar data before it is cached, exported, or consumed by downstream pipelines.
+
+Public API:
+    validate_ohlcv(df, *, interval, checks) -> ValidationResult
+    ValidationResult
+    Violation
+    ViolationType
+    DataIntegrityError
+    ContextValue
+    ViolationContext
+
+Example::
+
+    from tvkit.validation import validate_ohlcv
+
+    result = validate_ohlcv(df, interval="1D")
+    if result.is_valid:
+        await exporter.to_csv("output.csv")
+    else:
+        for v in result.violations:
+            logger.warning(v.message, extra={"check": v.check, "rows": v.affected_rows})
+"""
+
+from tvkit.validation.exceptions import DataIntegrityError
+from tvkit.validation.models import (
+    ContextValue,
+    ValidationResult,
+    Violation,
+    ViolationContext,
+    ViolationType,
+)
+from tvkit.validation.validator import validate_ohlcv
+
+__all__ = [
+    "validate_ohlcv",
+    "ValidationResult",
+    "Violation",
+    "ViolationType",
+    "DataIntegrityError",
+    "ContextValue",
+    "ViolationContext",
+]

--- a/tvkit/validation/checks.py
+++ b/tvkit/validation/checks.py
@@ -31,7 +31,7 @@ def _safe_float(value: Any) -> float | None:
 def _timestamp_diff_seconds(
     a: Any,
     b: Any,
-    dtype: pl.PolarsDataType,
+    dtype: pl.DataType,
 ) -> int:
     """
     Return the difference (b - a) in whole seconds.
@@ -300,7 +300,7 @@ def check_gaps(df: pl.DataFrame, interval: str) -> list[Violation]:
 
     for i in range(len(ts_list) - 1):
         actual_seconds = _timestamp_diff_seconds(ts_list[i], ts_list[i + 1], dtype)
-        if actual_seconds != expected_seconds:
+        if actual_seconds > expected_seconds:
             violations.append(
                 Violation(
                     check=ViolationType.GAP_DETECTED,

--- a/tvkit/validation/checks.py
+++ b/tvkit/validation/checks.py
@@ -1,0 +1,322 @@
+"""
+Individual OHLCV validation check functions.
+
+Each function is pure: no side effects, no logging, no mutation of input.
+All functions return list[Violation]. An empty list means no violations found.
+
+These functions assume the DataFrame schema has already been validated by
+_require_ohlcv_schema() in validator.py. They do not re-validate column
+existence or dtypes.
+
+check_gaps() is the only function that raises — it raises ValueError when
+called with an empty or unrecognised interval. All other functions never raise.
+"""
+
+import math
+from typing import Any
+
+import polars as pl
+
+from tvkit.validation.models import Violation, ViolationContext, ViolationType
+
+
+def _safe_float(value: Any) -> float | None:
+    """Return value as float, or None if it is NaN or null."""
+    if value is None:
+        return None
+    f = float(value)
+    return None if math.isnan(f) else f
+
+
+def _timestamp_diff_seconds(
+    a: Any,
+    b: Any,
+    dtype: pl.PolarsDataType,
+) -> int:
+    """
+    Return the difference (b - a) in whole seconds.
+
+    Handles four timestamp representations, all following tvkit's epoch-seconds convention:
+    - Float64: epoch seconds (default tvkit export — OHLCVBar.timestamp is a float in UTC seconds)
+    - Int64:   epoch seconds (tvkit integer timestamps; multiply by 1 to get seconds)
+    - Date:    Python datetime.date objects from .to_list() (days × 86400)
+    - Datetime: Python datetime.datetime objects from .to_list() (timedelta.total_seconds)
+
+    Note: Int64 timestamps in tvkit DataFrames are UTC epoch seconds, not milliseconds.
+    This is consistent with OHLCVBar.timestamp (float seconds), tvkit.time documentation,
+    and the PolarsFormatter which converts seconds→ms only on cast to Datetime.
+    """
+    import datetime
+
+    if dtype in (pl.Float64, pl.Float32, pl.Int64):
+        # epoch seconds — direct arithmetic
+        return round(float(b) - float(a))
+
+    # pl.Date and pl.Datetime both produce Python temporal objects via .to_list()
+    delta: datetime.timedelta = b - a  # type: ignore[operator]
+    return int(delta.total_seconds())
+
+
+def check_duplicate_timestamps(df: pl.DataFrame) -> list[Violation]:
+    """
+    Identify bars with duplicate timestamps.
+
+    Args:
+        df: Polars DataFrame with a validated OHLCV schema.
+
+    Returns:
+        One Violation per group of duplicate timestamps, sorted by the first
+        affected row index. Empty list if no duplicates are found.
+    """
+    if len(df) == 0:
+        return []
+
+    groups = (
+        df.with_row_index("_row_idx")
+        .group_by("timestamp")
+        .agg(
+            pl.col("_row_idx").alias("_indices"),
+            pl.len().alias("_count"),
+        )
+        .filter(pl.col("_count") > 1)
+    )
+
+    violations: list[Violation] = []
+    for row in groups.iter_rows(named=True):
+        affected: list[int] = sorted(row["_indices"])
+        ts_str = str(row["timestamp"])
+        count: int = int(row["_count"])
+        violations.append(
+            Violation(
+                check=ViolationType.DUPLICATE_TIMESTAMP,
+                severity="ERROR",
+                message=(
+                    f"Duplicate timestamp {ts_str!r} appears {count} time(s) at rows {affected}"
+                ),
+                affected_rows=affected,
+                context={"duplicate_timestamp": ts_str, "count": count},
+            )
+        )
+
+    violations.sort(key=lambda v: v.affected_rows[0] if v.affected_rows else 0)
+    return violations
+
+
+def check_monotonic_timestamps(df: pl.DataFrame) -> list[Violation]:
+    """
+    Detect out-of-order timestamps.
+
+    Checks that each bar's timestamp is strictly greater than the previous bar's
+    timestamp. Should be run after check_duplicate_timestamps so that equal-value
+    pairs are reported as duplicates before being reported here.
+
+    Args:
+        df: Polars DataFrame with a validated OHLCV schema.
+
+    Returns:
+        One Violation per out-of-order consecutive pair. Empty list if all
+        timestamps are strictly increasing.
+    """
+    if len(df) <= 1:
+        return []
+
+    ts_list = df["timestamp"].to_list()
+    violations: list[Violation] = []
+
+    for i in range(len(ts_list) - 1):
+        curr_val = ts_list[i]
+        next_val = ts_list[i + 1]
+        if next_val <= curr_val:
+            violations.append(
+                Violation(
+                    check=ViolationType.NON_MONOTONIC_TIMESTAMP,
+                    severity="ERROR",
+                    message=(
+                        f"Timestamp at row {i + 1} ({str(next_val)!r}) is not strictly "
+                        f"greater than row {i} ({str(curr_val)!r})"
+                    ),
+                    affected_rows=[i, i + 1],
+                    context={
+                        "prev_timestamp": str(curr_val),
+                        "curr_timestamp": str(next_val),
+                    },
+                )
+            )
+
+    return violations
+
+
+def check_ohlc_consistency(df: pl.DataFrame) -> list[Violation]:
+    """
+    Enforce OHLC price constraints for every bar.
+
+    For each bar checks:
+    - low <= open <= high
+    - low <= close <= high
+    - No NaN or null values in open, high, low, close
+
+    Args:
+        df: Polars DataFrame with a validated OHLCV schema.
+
+    Returns:
+        One Violation per bar that fails any constraint. Empty list if all bars
+        pass. NaN and null values are treated as violations.
+    """
+    if len(df) == 0:
+        return []
+
+    opens = df["open"].to_list()
+    highs = df["high"].to_list()
+    lows = df["low"].to_list()
+    closes = df["close"].to_list()
+
+    violations: list[Violation] = []
+
+    for i, (o, h, low_val, c) in enumerate(zip(opens, highs, lows, closes, strict=False)):
+        violated: str | None = None
+
+        has_null_or_nan = any(
+            v is None or (isinstance(v, float) and math.isnan(v)) for v in (o, h, low_val, c)
+        )
+
+        if has_null_or_nan:
+            violated = "NaN or null value in OHLC column"
+        elif not (low_val <= o <= h):  # type: ignore[operator]
+            violated = f"low ({low_val}) \u2264 open ({o}) \u2264 high ({h}) violated"
+        elif not (low_val <= c <= h):  # type: ignore[operator]
+            violated = f"low ({low_val}) \u2264 close ({c}) \u2264 high ({h}) violated"
+
+        if violated is not None:
+            ctx: ViolationContext = {
+                "open": _safe_float(o),
+                "high": _safe_float(h),
+                "low": _safe_float(low_val),
+                "close": _safe_float(c),
+                "violated_constraint": violated,
+            }
+            violations.append(
+                Violation(
+                    check=ViolationType.OHLC_INCONSISTENCY,
+                    severity="ERROR",
+                    message=f"OHLC constraint violated at row {i}: {violated}",
+                    affected_rows=[i],
+                    context=ctx,
+                )
+            )
+
+    return violations
+
+
+def check_volume_non_negative(df: pl.DataFrame) -> list[Violation]:
+    """
+    Detect bars with negative or NaN volume.
+
+    Args:
+        df: Polars DataFrame with a validated OHLCV schema.
+
+    Returns:
+        One Violation per bar with volume < 0 or NaN/null volume. Empty list
+        if all volume values are valid non-negative numbers.
+    """
+    if len(df) == 0:
+        return []
+
+    volumes = df["volume"].to_list()
+    violations: list[Violation] = []
+
+    for i, v in enumerate(volumes):
+        is_null_or_nan = v is None or (isinstance(v, float) and math.isnan(v))
+
+        if is_null_or_nan:
+            violations.append(
+                Violation(
+                    check=ViolationType.NEGATIVE_VOLUME,
+                    severity="ERROR",
+                    message=f"Null or NaN volume at row {i}",
+                    affected_rows=[i],
+                    context={"volume": None},
+                )
+            )
+        elif v < 0:
+            violations.append(
+                Violation(
+                    check=ViolationType.NEGATIVE_VOLUME,
+                    severity="ERROR",
+                    message=f"Negative volume {v} at row {i}",
+                    affected_rows=[i],
+                    context={"volume": float(v)},
+                )
+            )
+
+    return violations
+
+
+def check_gaps(df: pl.DataFrame, interval: str) -> list[Violation]:
+    """
+    Find missing bars given the expected interval cadence.
+
+    Uses validate_interval() and interval_to_seconds() from tvkit.api.chart.utils
+    to validate the interval string and compute the expected gap duration.
+
+    Phase 1 limitation: cadence-only, not calendar-aware. For daily equity data,
+    weekends and public holidays are reported as WARNING violations. The caller is
+    responsible for filtering expected calendar gaps.
+
+    Args:
+        df: Polars DataFrame with a validated OHLCV schema.
+        interval: Expected interval string (e.g., "1D", "1H", "15", "5S").
+                  Must be a non-empty, recognised TradingView interval with a
+                  fixed cadence (seconds, minutes, hours, or days).
+
+    Returns:
+        One WARNING Violation per gap found, with affected_rows pointing to the
+        bar immediately after the gap. Empty list if no gaps are found.
+
+    Raises:
+        ValueError: If interval is empty, unrecognised, or a variable-cadence
+                    monthly/weekly interval that cannot be converted to seconds.
+        TypeError:  If interval is not a string (propagated from validate_interval).
+    """
+    from tvkit.api.chart.utils import interval_to_seconds, validate_interval
+
+    validate_interval(interval)  # raises ValueError / TypeError for invalid format
+
+    try:
+        expected_seconds = interval_to_seconds(interval)
+    except ValueError as exc:
+        raise ValueError(
+            f"Gap detection requires a fixed-cadence interval (seconds, minutes, "
+            f"hours, or days). Monthly and weekly intervals have variable-length "
+            f"durations and cannot be used for cadence-based gap detection. "
+            f"Got {interval!r}."
+        ) from exc
+
+    if len(df) <= 1:
+        return []
+
+    ts_list = df["timestamp"].to_list()
+    dtype = df["timestamp"].dtype
+    violations: list[Violation] = []
+
+    for i in range(len(ts_list) - 1):
+        actual_seconds = _timestamp_diff_seconds(ts_list[i], ts_list[i + 1], dtype)
+        if actual_seconds != expected_seconds:
+            violations.append(
+                Violation(
+                    check=ViolationType.GAP_DETECTED,
+                    severity="WARNING",
+                    message=(
+                        f"Gap detected between rows {i} and {i + 1}: "
+                        f"expected {expected_seconds}s, got {actual_seconds}s"
+                    ),
+                    affected_rows=[i + 1],
+                    context={
+                        "expected_interval": interval,
+                        "actual_gap": f"{actual_seconds}s",
+                        "prev_timestamp": str(ts_list[i]),
+                        "curr_timestamp": str(ts_list[i + 1]),
+                    },
+                )
+            )
+
+    return violations

--- a/tvkit/validation/exceptions.py
+++ b/tvkit/validation/exceptions.py
@@ -1,0 +1,27 @@
+"""
+Public exceptions for tvkit.validation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tvkit.validation.models import ValidationResult
+
+
+class DataIntegrityError(Exception):
+    """
+    Raised when OHLCV data fails validation and strict mode is enabled.
+
+    Attributes:
+        result: The full ValidationResult containing all violations found.
+    """
+
+    def __init__(self, result: ValidationResult) -> None:
+        error_count = len(result.errors)
+        super().__init__(
+            f"OHLCV data integrity check failed: {error_count} error(s) found. "
+            f"Inspect result.errors for details."
+        )
+        self.result = result

--- a/tvkit/validation/models.py
+++ b/tvkit/validation/models.py
@@ -1,0 +1,81 @@
+"""
+Pydantic models for tvkit.validation.
+
+Defines the data types used to represent validation results and violations.
+"""
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ViolationType(StrEnum):
+    """Enumeration of all supported OHLCV validation check types."""
+
+    DUPLICATE_TIMESTAMP = "duplicate_timestamp"
+    NON_MONOTONIC_TIMESTAMP = "non_monotonic_timestamp"
+    OHLC_INCONSISTENCY = "ohlc_inconsistency"
+    NEGATIVE_VOLUME = "negative_volume"
+    GAP_DETECTED = "gap_detected"
+
+
+# Tightly-typed context value — no Any
+ContextValue = str | int | float | bool | None
+ViolationContext = dict[str, ContextValue]
+
+
+class Violation(BaseModel):
+    """A single data integrity violation found in an OHLCV DataFrame."""
+
+    check: ViolationType = Field(description="The validation check that produced this violation")
+    severity: Literal["ERROR", "WARNING"] = Field(description="Severity level of this violation")
+    message: str = Field(description="Human-readable description of the violation")
+    affected_rows: list[int] = Field(
+        default_factory=list,
+        description="Row indices (0-based) in the input DataFrame containing the violation",
+    )
+    context: ViolationContext = Field(
+        default_factory=dict,
+        description="Structured context values (str, int, float, bool, or None only)",
+    )
+
+
+class ValidationResult(BaseModel):
+    """Aggregate result of all validation checks on an OHLCV DataFrame."""
+
+    is_valid: bool = Field(
+        description=(
+            "True if there are zero ERROR-level violations. "
+            "WARNING violations do not affect this flag."
+        )
+    )
+    violations: list[Violation] = Field(
+        default_factory=list,
+        description=(
+            "All violations found, in deterministic order: "
+            "sorted by check execution order, then by row index within each check."
+        ),
+    )
+    bars_checked: int = Field(description="Total number of bars examined")
+    checks_run: list[ViolationType] = Field(
+        description="Ordered list of checks that were executed, in execution order"
+    )
+
+    @property
+    def errors(self) -> list[Violation]:
+        """
+        Return only ERROR-severity violations.
+
+        Convenience accessor — not serialized by model_dump().
+        """
+        return [v for v in self.violations if v.severity == "ERROR"]
+
+    @property
+    def warnings(self) -> list[Violation]:
+        """
+        Return only WARNING-severity violations.
+
+        Convenience accessor — not serialized by model_dump().
+        """
+        return [v for v in self.violations if v.severity == "WARNING"]

--- a/tvkit/validation/validator.py
+++ b/tvkit/validation/validator.py
@@ -1,0 +1,182 @@
+"""
+Composite OHLCV validator.
+
+Provides validate_ohlcv() — the single public entry point that orchestrates
+all check functions in deterministic order — and the private schema helper
+_require_ohlcv_schema().
+"""
+
+import polars as pl
+
+from tvkit.validation.checks import (
+    check_duplicate_timestamps,
+    check_gaps,
+    check_monotonic_timestamps,
+    check_ohlc_consistency,
+    check_volume_non_negative,
+)
+from tvkit.validation.models import ValidationResult, Violation, ViolationType
+
+# Required columns and their accepted Polars dtypes.
+#
+# Notes:
+# - pl.Float64 is included for timestamp because tvkit's PolarsFormatter produces
+#   Float64 timestamp columns (UTC epoch seconds from OHLCVBar.timestamp: float).
+# - pl.Int64 is included for timestamp because callers may cast Float64 → Int64;
+#   the convention is epoch seconds in both cases.
+# - pl.Datetime entries are handled via isinstance() in _require_ohlcv_schema because
+#   Datetime is parameterised (time_unit, time_zone) and equality against the bare
+#   class always returns False for instantiated variants like Datetime('us', None).
+_REQUIRED_COLUMNS: dict[str, tuple[pl.PolarsDataType, ...]] = {
+    "timestamp": (pl.Float64, pl.Int64, pl.Date),  # Datetime handled via isinstance
+    "open": (pl.Float64, pl.Float32),
+    "high": (pl.Float64, pl.Float32),
+    "low": (pl.Float64, pl.Float32),
+    "close": (pl.Float64, pl.Float32),
+    "volume": (pl.Float64, pl.Float32, pl.Int64),
+}
+
+# Deterministic execution order — part of the public contract.
+_CHECK_ORDER: list[ViolationType] = [
+    ViolationType.DUPLICATE_TIMESTAMP,
+    ViolationType.NON_MONOTONIC_TIMESTAMP,
+    ViolationType.OHLC_INCONSISTENCY,
+    ViolationType.NEGATIVE_VOLUME,
+    ViolationType.GAP_DETECTED,
+]
+
+_ALL_CHECK_TYPES: frozenset[ViolationType] = frozenset(ViolationType)
+
+
+def _require_ohlcv_schema(df: pl.DataFrame) -> None:
+    """
+    Verify that df has all required OHLCV columns with acceptable dtypes.
+
+    Called at the start of validate_ohlcv() before any check executes.
+    Empty DataFrames (zero rows) pass without error.
+
+    Args:
+        df: Polars DataFrame to inspect.
+
+    Raises:
+        ValueError: If any required column is missing or has an unsupported dtype.
+    """
+    for col, accepted in _REQUIRED_COLUMNS.items():
+        if col not in df.columns:
+            raise ValueError(
+                f"Required column {col!r} is missing from the DataFrame. "
+                f"Expected columns: {list(_REQUIRED_COLUMNS)}"
+            )
+        dtype = df[col].dtype
+        is_datetime = col == "timestamp" and isinstance(dtype, pl.Datetime)
+        if not is_datetime and dtype not in accepted:
+            if col == "timestamp":
+                accepted_names = "Float64, Int64, Datetime, Date"
+            else:
+                accepted_names = ", ".join(str(d) for d in accepted)
+            raise ValueError(
+                f"Column {col!r} has unsupported dtype {dtype!r}. Accepted: {accepted_names}"
+            )
+
+
+def validate_ohlcv(
+    df: pl.DataFrame,
+    *,
+    interval: str | None = None,
+    checks: list[ViolationType] | None = None,
+) -> ValidationResult:
+    """
+    Validate the integrity of an OHLCV Polars DataFrame.
+
+    Runs checks in deterministic order:
+    1. DUPLICATE_TIMESTAMP
+    2. NON_MONOTONIC_TIMESTAMP
+    3. OHLC_INCONSISTENCY
+    4. NEGATIVE_VOLUME
+    5. GAP_DETECTED (only when interval is provided, or explicitly requested)
+
+    Args:
+        df: Polars DataFrame with required columns: timestamp, open, high,
+            low, close, volume.
+        interval: Optional interval string (e.g., "1D", "1H") required for
+                  gap detection. If None and GAP_DETECTED is not explicitly in
+                  checks, gap detection is silently skipped. If None and
+                  ViolationType.GAP_DETECTED is explicitly in checks, raises
+                  ValueError.
+        checks: Optional subset of checks to run. If None, all applicable
+                checks are run in the fixed deterministic order (GAP_DETECTED
+                only if interval is provided). All items must be valid
+                ViolationType members — unknown values raise ValueError.
+
+    Returns:
+        ValidationResult with:
+        - is_valid: False if and only if at least one ERROR-level violation exists
+        - violations: sorted by check execution order, then by row index
+        - bars_checked: total rows examined
+        - checks_run: ordered list of executed check types
+
+    Raises:
+        ValueError: If df is missing required columns, any column has an
+                    unsupported dtype, checks contains an unknown ViolationType,
+                    or GAP_DETECTED is explicitly requested without interval.
+
+    Example::
+
+        >>> result = validate_ohlcv(df, interval="1D")
+        >>> if not result.is_valid:
+        ...     for v in result.errors:
+        ...         logger.error(v.message, extra={"rows": v.affected_rows})
+    """
+    _require_ohlcv_schema(df)
+
+    if checks is None:
+        # Default: run all checks; silently skip GAP_DETECTED when no interval given.
+        checks_to_run = [
+            c for c in _CHECK_ORDER if c != ViolationType.GAP_DETECTED or interval is not None
+        ]
+    else:
+        # Reject unknown check types up front — a typo or wrong value must be an
+        # immediate error, not a silent no-op that returns is_valid=True.
+        unknown = [c for c in checks if c not in _ALL_CHECK_TYPES]
+        if unknown:
+            raise ValueError(
+                f"Unknown check type(s): {unknown!r}. "
+                f"Valid values: {[v.value for v in ViolationType]}"
+            )
+
+        # Guard: explicit GAP_DETECTED requires interval.
+        if ViolationType.GAP_DETECTED in checks and interval is None:
+            raise ValueError(
+                "interval is required when ViolationType.GAP_DETECTED is included "
+                "in checks. Provide interval='1D' (or the appropriate interval), "
+                "or omit GAP_DETECTED from checks."
+            )
+        checks_to_run = list(checks)
+
+    all_violations: list[Violation] = []
+
+    # Execute in the fixed deterministic order, filtered to the requested checks.
+    for check_type in _CHECK_ORDER:
+        if check_type not in checks_to_run:
+            continue
+
+        if check_type == ViolationType.DUPLICATE_TIMESTAMP:
+            all_violations.extend(check_duplicate_timestamps(df))
+        elif check_type == ViolationType.NON_MONOTONIC_TIMESTAMP:
+            all_violations.extend(check_monotonic_timestamps(df))
+        elif check_type == ViolationType.OHLC_INCONSISTENCY:
+            all_violations.extend(check_ohlc_consistency(df))
+        elif check_type == ViolationType.NEGATIVE_VOLUME:
+            all_violations.extend(check_volume_non_negative(df))
+        elif check_type == ViolationType.GAP_DETECTED and interval is not None:
+            all_violations.extend(check_gaps(df, interval))
+
+    has_errors = any(v.severity == "ERROR" for v in all_violations)
+    executed = [c for c in _CHECK_ORDER if c in checks_to_run]
+
+    return ValidationResult(
+        is_valid=not has_errors,
+        violations=all_violations,
+        bars_checked=len(df),
+        checks_run=executed,
+    )

--- a/tvkit/validation/validator.py
+++ b/tvkit/validation/validator.py
@@ -27,7 +27,7 @@ from tvkit.validation.models import ValidationResult, Violation, ViolationType
 # - pl.Datetime entries are handled via isinstance() in _require_ohlcv_schema because
 #   Datetime is parameterised (time_unit, time_zone) and equality against the bare
 #   class always returns False for instantiated variants like Datetime('us', None).
-_REQUIRED_COLUMNS: dict[str, tuple[pl.PolarsDataType, ...]] = {
+_REQUIRED_COLUMNS: dict[str, tuple[type[pl.DataType], ...]] = {
     "timestamp": (pl.Float64, pl.Int64, pl.Date),  # Datetime handled via isinstance
     "open": (pl.Float64, pl.Float32),
     "high": (pl.Float64, pl.Float32),


### PR DESCRIPTION
## Summary

- Add `tvkit.validation` module with data integrity checks for OHLCV Polars DataFrames
- Integrate opt-in validation into `DataExporter.to_csv()` and `to_json()` via `validate`, `strict`, and `interval` keyword params
- Add `DataIntegrityError` public exception (carries full `ValidationResult`) raised in strict mode
- Bump package version `0.8.0` → `0.9.0`; published to PyPI as `tvkit==0.9.0`

## Checks Implemented (deterministic execution order)

| # | Check | Severity | Description |
|---|---|---|---|
| 1 | Duplicate timestamps | ERROR | No two bars share the same timestamp |
| 2 | Monotonic timestamps | ERROR | Timestamps must be strictly increasing |
| 3 | OHLC consistency | ERROR | `low ≤ open ≤ high`, `low ≤ close ≤ high` for every bar |
| 4 | Non-negative volume | ERROR | Volume must be ≥ 0, no NaN |
| 5 | Gap detection | WARNING | No missing bars given the expected interval cadence |

## Design Notes

- `validate_ohlcv(df)` without `interval` silently skips gap detection; only explicit `checks=[ViolationType.GAP_DETECTED]` without `interval` raises `ValueError`
- `ValidationResult.is_valid` is `False` only on ERROR violations — WARNING-only results remain valid
- Phase 1 gap detection is cadence-only (not calendar-aware); daily equity weekend/holiday gaps appear as WARNING violations by design
- All check functions are pure (no side effects, no mutation of input DataFrame)
- `errors` and `warnings` on `ValidationResult` are `@property` accessors — not serialized by `model_dump()`

## Quality Gates

| Gate | Result |
|---|---|
| `ruff check .` | ✅ All checks passed |
| `ruff format .` | ✅ 92 files unchanged |
| `mypy tvkit/` | ✅ No issues in 60 source files |
| `pytest tests/ -v` | ✅ 905 passed, 2 skipped, 0 failed |

## Phases Completed

- **Phase 0:** Planning & scaffolding — full module scaffold
- **Phase 1:** Core models, exceptions & individual checks (unit tests, 100% public API coverage)
- **Phase 2:** Composite `validate_ohlcv()` validator (50 integration tests)
- **Phase 3:** `DataExporter` integration (25 tests)
- **Phase 4:** Documentation — reference docs, concept doc, guide, example, CHANGELOG entry
- **Phase 5:** Version bump, quality gates, PyPI publication, this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)