### PR TITLE
feat(batch): Async Batch Downloader — tvkit.batch v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] — 2026-04-20
+
+### Added
+
+- **`tvkit.batch` module** — high-throughput async batch downloader for historical OHLCV data:
+  - `batch_download(request)` — async function that fetches historical OHLCV bars for a list of
+    symbols concurrently; returns `BatchDownloadSummary` with one `SymbolResult` per symbol
+  - `BatchDownloadRequest` — Pydantic-validated input model; supports bar-count mode
+    (`bars_count`) and date-range mode (`start`/`end`); `auth_token` stored as `SecretStr`
+  - `BatchDownloadSummary` — aggregated result with `success_count`, `failure_count`,
+    `elapsed_seconds`, `interval`, and `@computed_field` properties `failed_symbols` /
+    `successful_symbols` (appear in `model_dump()`)
+  - `SymbolResult` — per-symbol result with `bars`, `success`, `error`, `attempts`,
+    `elapsed_seconds`; invariants enforced by `@model_validator`
+  - `ErrorInfo` — structured error record with `message`, `exception_type`, `attempt`
+    (`attempt=0` for pre-flight rejections, `1+` for fetch attempts)
+  - `BatchDownloadError` — raised in `strict=True` mode or by `raise_if_failed()`; carries
+    the full `BatchDownloadSummary` including partial successes on `.summary`
+  - `BatchDownloadSummary.raise_if_failed()` — deferred strict-mode check callable after
+    the fact; useful for pipelines that inspect before deciding whether failures are fatal
+- **Bounded concurrency** — `asyncio.Semaphore` acquired **per network attempt**, not per retry
+  loop; backoff sleep never occupies a concurrency slot
+- **Per-symbol retry with exponential backoff** — `StreamConnectionError`,
+  `websockets.WebSocketException`, `TimeoutError` are retried up to `max_attempts` times;
+  `ValueError` and `NoHistoricalDataError` are not retried
+- **Partial failure model** — failed symbols are collected in `BatchDownloadSummary` by default;
+  no exception raised unless `strict=True`; `raise_if_failed()` provides deferred raise
+- **Symbol normalization and deduplication** — all inputs normalized via `tvkit.symbols` and
+  deduplicated (order-preserving) before dispatch; `total_count` reflects deduplicated count
+- **Opt-in pre-flight symbol validation** — `validate_symbols_before_fetch=True` validates all
+  symbols via TradingView HTTP API before any WebSocket fetch; confirmed-invalid symbols become
+  `SymbolResult(success=False, attempts=0)` immediately; transport failures fail open
+- **Progress callback** — `on_progress: Callable[[SymbolResult, int, int], None]` invoked once
+  per symbol after its terminal result; async callables rejected at construction
+- **`SymbolValidationOutcome` model** — added to `tvkit.api.utils.symbol_validator` to support
+  pre-flight validation; exposes `is_valid`, `is_known_invalid`, and `message` fields
+- **`validate_symbol_detailed()`** — new async function in `tvkit.api.utils.symbol_validator`
+  returning `SymbolValidationOutcome`; exposed via `tvkit.api.utils`
+
+### Notes
+
+- `tvkit.batch` is a consumer of `tvkit.api.chart.OHLCV` — it instantiates one `OHLCV` client
+  per in-flight attempt. WebSocket multiplexing (sharing one connection across subscriptions) is
+  listed in `docs/roadmap.md` under **Under Consideration** and is out of scope for this release.
+- No breaking changes to existing APIs — `tvkit.api.chart.OHLCV` is unchanged.
+- `ErrorInfo.attempt` and `SymbolResult.attempts` minimum is `0` (pre-flight) rather than `1`;
+  this is additive and does not affect existing code that only uses non-pre-flight paths.
+
 ## [0.9.0] — 2026-04-09
 
 ### Added

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -9,38 +9,40 @@ tvkit/
 ├── tvkit.api.chart          # Real-time WebSocket streaming
 ├── tvkit.api.scanner        # HTTP-based market scanner
 ├── tvkit.api.utils          # Shared utilities (symbols, timestamps, indicators)
+├── tvkit.batch              # Async high-throughput batch OHLCV downloader
 └── tvkit.export             # Multi-format data export
 ```
 
 ## Component Diagram
 
 ```text
-┌─────────────────────────────────────────────────────────────────┐
-│                        Your Application                          │
-└───────────┬──────────────┬──────────────┬────────────────────────┘
-            │              │              │
-            ▼              ▼              ▼
-   ┌────────────────┐ ┌──────────────┐ ┌───────────────┐
-   │  tvkit.api.    │ │ tvkit.api.   │ │ tvkit.export  │
-   │  chart         │ │ scanner      │ │               │
-   │  ──────────    │ │ ──────────── │ │ ─────────────  │
-   │  OHLCV client  │ │ ScannerSvc   │ │ DataExporter  │
-   │  ConnectionSvc │ │ 69 markets   │ │ PolarsFormatter│
-   │  MessageSvc    │ │ 100+ cols    │ │ JSONFormatter │
-   │  SegmentedFetch│ │              │ │ CSVFormatter  │
-   └───────┬────────┘ └──────┬───────┘ └───────┬───────┘
-           │                 │                 │
-           │ WebSocket       │ HTTPS           │
-           ▼                 ▼                 │
-   ┌──────────────────────────────────┐        │
-   │       TradingView APIs           │        │
-   │  wss://data.tradingview.com/...  │        │
-   │  https://scanner.tradingview.com │        │
-   └──────────────────────────────────┘        │
-                                               ▼
-                                    ┌────────────────────┐
-                                    │  Polars / JSON / CSV│
-                                    └────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            Your Application                              │
+└───────────┬──────────────┬──────────────┬──────────────┬────────────────┘
+            │              │              │              │
+            ▼              ▼              ▼              ▼
+   ┌────────────────┐ ┌──────────────┐ ┌─────────────┐ ┌───────────────┐
+   │  tvkit.api.    │ │ tvkit.api.   │ │ tvkit.batch │ │ tvkit.export  │
+   │  chart         │ │ scanner      │ │             │ │               │
+   │  ──────────    │ │ ──────────── │ │ ─────────── │ │ ─────────────  │
+   │  OHLCV client  │ │ ScannerSvc   │ │ batch_      │ │ DataExporter  │
+   │  ConnectionSvc │ │ 69 markets   │ │ download()  │ │ PolarsFormatter│
+   │  MessageSvc    │ │ 100+ cols    │ │ Semaphore   │ │ JSONFormatter │
+   │  SegmentedFetch│ │              │ │ retry/backoff│ │ CSVFormatter  │
+   └───────┬────────┘ └──────┬───────┘ └──────┬──────┘ └───────┬───────┘
+           │                 │                │                 │
+           │ WebSocket       │ HTTPS          │ WebSocket       │
+           │                 │                │ (one per symbol)│
+           ▼                 ▼                ▼                 │
+   ┌──────────────────────────────────────────────────┐         │
+   │                  TradingView APIs                │         │
+   │  wss://data.tradingview.com/...                  │         │
+   │  https://scanner.tradingview.com                 │         │
+   └──────────────────────────────────────────────────┘         │
+                                                                ▼
+                                                     ┌────────────────────┐
+                                                     │  Polars / JSON / CSV│
+                                                     └────────────────────┘
 ```
 
 ## Module Descriptions

--- a/docs/guides/batch-download.md
+++ b/docs/guides/batch-download.md
@@ -1,0 +1,323 @@
+# Batch Download Guide
+
+`tvkit.batch` provides `batch_download()` — an async function for fetching historical OHLCV data for large symbol sets concurrently. It handles bounded concurrency, per-symbol retry with exponential backoff, and structured partial-failure reporting.
+
+---
+
+## When to use `tvkit.batch`
+
+Use `batch_download()` when you need to fetch historical bars for more than a handful of symbols. The single-symbol `OHLCV.get_historical_ohlcv()` is fine for one to a few symbols; for larger sets, manual `asyncio.gather()` loops overwhelm TradingView's server without a concurrency cap.
+
+`batch_download()` handles:
+
+- **Bounded concurrency** — a semaphore caps in-flight WebSocket connections
+- **Per-symbol retry** — transient failures are retried with exponential backoff
+- **Partial failure** — failed symbols are collected, not raised (by default)
+- **Deduplication** — normalized duplicates are fetched only once
+
+---
+
+## Installation
+
+`tvkit.batch` is included in `tvkit`. No extra dependencies are required.
+
+```bash
+uv add tvkit
+```
+
+---
+
+## Basic Usage: bars-count mode
+
+Fetch the N most recent bars for each symbol:
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+async def main() -> None:
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NASDAQ:NVDA"],
+        interval="1D",
+        bars_count=252,   # ~1 year of daily bars
+        concurrency=5,
+    )
+    summary = await batch_download(request)
+
+    for result in summary.results:
+        if result.success:
+            print(f"{result.symbol}: {len(result.bars)} bars, last close {result.bars[-1].close}")
+        else:
+            print(f"{result.symbol}: FAILED — {result.error.message}")
+
+    print(f"Done: {summary.success_count}/{summary.total_count} in {summary.elapsed_seconds:.1f}s")
+
+asyncio.run(main())
+```
+
+---
+
+## Date-range mode
+
+Fetch bars over a specific date range:
+
+```python
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1D",
+    start="2024-01-01",
+    end="2024-12-31",
+    concurrency=10,
+)
+summary = await batch_download(request)
+```
+
+- `start` and `end` accept ISO 8601 strings or `datetime` objects.
+- Naive `datetime` objects are treated as UTC.
+- `end` defaults to the current time if only `start` is provided.
+
+---
+
+## Progress reporting
+
+Pass a sync callback to track progress as symbols complete:
+
+```python
+from tvkit.batch import batch_download, BatchDownloadRequest, SymbolResult
+
+def on_progress(result: SymbolResult, completed: int, total: int) -> None:
+    status = "OK" if result.success else "FAIL"
+    print(f"[{completed}/{total}] {result.symbol} — {status}")
+
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1D",
+    bars_count=252,
+    on_progress=on_progress,
+)
+summary = await batch_download(request)
+```
+
+**Callback contract:**
+- Called once per symbol, after its terminal result (success or final-attempt failure).
+- `completed` is 1-based; `total` is the deduplicated symbol count.
+- The callback must be **synchronous** — async callables are rejected at construction.
+- Exceptions raised by the callback are logged and swallowed — a bad callback does not abort the batch.
+
+---
+
+## Handling partial failures
+
+By default, `batch_download()` collects failures and always returns a `BatchDownloadSummary`:
+
+```python
+summary = await batch_download(request)
+
+# Inspect per-symbol outcomes
+for result in summary.results:
+    if result.success:
+        process(result.symbol, result.bars)
+    else:
+        logger.error(
+            "Symbol failed after %d attempts: %s",
+            result.attempts,
+            result.error.message,
+        )
+
+# Print a concise summary
+print(f"Success: {summary.success_count}/{summary.total_count}")
+print(f"Failed symbols: {summary.failed_symbols}")
+```
+
+### Strict mode — raise on any failure
+
+Set `strict=True` to raise `BatchDownloadError` if any symbol fails:
+
+```python
+from tvkit.batch import batch_download, BatchDownloadRequest, BatchDownloadError
+
+try:
+    request = BatchDownloadRequest(
+        symbols=symbols,
+        interval="1D",
+        bars_count=252,
+        strict=True,
+    )
+    summary = await batch_download(request)
+except BatchDownloadError as exc:
+    print(f"Batch failed: {exc.failed_symbols}")
+    # Partial results are still available on exc.summary:
+    for result in exc.summary.results:
+        if result.success:
+            process(result)
+```
+
+### Deferred error check — `raise_if_failed()`
+
+Inspect the summary first, then raise if needed:
+
+```python
+summary = await batch_download(request)
+
+# Export whatever succeeded immediately
+for result in summary.results:
+    if result.success:
+        await exporter.to_csv(result.bars, f"export/{result.symbol.replace(':', '_')}.csv")
+
+# Now assert no failures (raises if any symbol failed)
+summary.raise_if_failed()
+```
+
+---
+
+## Authenticated batch download
+
+Pass `auth_token` to access premium account limits and extended history:
+
+```python
+import os
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1H",
+    bars_count=10_000,
+    concurrency=5,
+    auth_token=os.environ["TVKIT_AUTH_TOKEN"],  # stored as SecretStr — never logged
+)
+summary = await batch_download(request)
+```
+
+Or use browser cookie extraction:
+
+```python
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1D",
+    bars_count=500,
+    browser="chrome",  # or "firefox"
+)
+```
+
+---
+
+## Pre-flight symbol validation
+
+Enable `validate_symbols_before_fetch` to reject clearly invalid symbols before any WebSocket connection is opened:
+
+```python
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1D",
+    bars_count=252,
+    validate_symbols_before_fetch=True,
+)
+summary = await batch_download(request)
+```
+
+- Symbols confirmed invalid (HTTP 404) become `SymbolResult(success=False, attempts=0)` immediately.
+- Validation failures due to transport or server errors **fail open** — the symbol proceeds to the fetch phase unchanged.
+- Pre-flight results use `error.attempt=0` to distinguish them from fetch-phase failures.
+
+> **Note**: Each symbol requires one HTTP call before fetching begins. Not recommended for batches > 200 symbols.
+
+---
+
+## Tuning concurrency and retry
+
+```python
+request = BatchDownloadRequest(
+    symbols=symbols,
+    interval="1D",
+    bars_count=500,
+    concurrency=10,       # up to 10 in-flight connections
+    max_attempts=5,       # retry each symbol up to 5 times
+    base_backoff=0.5,     # start with 0.5s backoff
+    max_backoff=60.0,     # cap backoff at 60s
+)
+```
+
+**Semaphore behavior**: The semaphore is acquired **per network attempt**, not per retry loop. Backoff sleep is outside the semaphore — other symbols make progress while this one waits.
+
+**Retryable exceptions**: `StreamConnectionError`, `websockets.WebSocketException`, `TimeoutError`
+
+**Non-retryable exceptions**: `ValueError` (bad input), `NoHistoricalDataError` (TradingView confirms no data exists)
+
+---
+
+## Deduplication and normalization
+
+Input symbols are normalized to `EXCHANGE:SYMBOL` format and deduplicated before dispatch. The `BatchDownloadSummary` reflects the deduplicated count.
+
+```python
+# These 5 inputs deduplicate to 3 unique symbols
+request = BatchDownloadRequest(
+    symbols=[
+        "NASDAQ:AAPL",
+        "nasdaq:aapl",    # case variant → same as NASDAQ:AAPL
+        "NASDAQ:MSFT",
+        "NASDAQ:MSFT",    # exact duplicate
+        "NYSE:JPM",
+    ],
+    interval="1D",
+    bars_count=10,
+)
+summary = await batch_download(request)
+assert summary.total_count == 3
+assert len(summary.results) == 3
+```
+
+---
+
+## Exporting results
+
+Combine with `tvkit.export.DataExporter` to save results to CSV or JSON:
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest
+from tvkit.export import DataExporter
+
+async def main() -> None:
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+        interval="1D",
+        bars_count=252,
+    )
+    summary = await batch_download(request)
+
+    exporter = DataExporter()
+    for result in summary.results:
+        if result.success:
+            filename = result.symbol.replace(":", "_")
+            await exporter.to_csv(result.bars, f"export/{filename}.csv")
+            print(f"Exported {result.symbol} → export/{filename}.csv")
+
+asyncio.run(main())
+```
+
+---
+
+## Runnable example
+
+A complete demo script covering all major patterns is available at [examples/batch_sp500_historical.py](../../examples/batch_sp500_historical.py):
+
+```bash
+uv run python examples/batch_sp500_historical.py
+```
+
+Demos included:
+1. Basic batch with rich progress bar
+2. Deduplication behavior
+3. Partial failure with `strict=False`
+4. Strict mode with `BatchDownloadError`
+
+---
+
+## See Also
+
+- [API Reference: tvkit.batch](../reference/batch/downloader.md) — complete parameter tables and model definitions
+- [OHLCV Client](../reference/chart/ohlcv.md) — the underlying single-symbol client
+- [DataExporter](../reference/export/exporter.md) — export results to CSV, JSON, or Polars

--- a/docs/reference/batch/downloader.md
+++ b/docs/reference/batch/downloader.md
@@ -1,0 +1,374 @@
+# `tvkit.batch` — Batch Downloader Reference
+
+**Module:** `tvkit.batch`
+**Introduced in:** v1.0.0
+
+High-throughput async batch downloader for historical OHLCV data. Fetches multiple symbols concurrently with bounded concurrency, per-symbol retry with exponential backoff, and a structured result summary separating successes from failures.
+
+## Quick Example
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+async def main() -> None:
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
+        interval="1D",
+        bars_count=252,
+        concurrency=5,
+    )
+    summary = await batch_download(request)
+
+    for result in summary.results:
+        if result.success and result.bars:
+            print(f"{result.symbol}: {len(result.bars)} bars, last close {result.bars[-1].close}")
+        elif not result.success:
+            print(f"{result.symbol}: FAILED — {result.error.message}")
+
+    print(f"Success: {summary.success_count}/{summary.total_count} in {summary.elapsed_seconds:.1f}s")
+
+asyncio.run(main())
+```
+
+---
+
+## Import
+
+```python
+from tvkit.batch import (
+    batch_download,
+    BatchDownloadRequest,
+    BatchDownloadSummary,
+    SymbolResult,
+    ErrorInfo,
+    BatchDownloadError,
+)
+```
+
+---
+
+## `batch_download()`
+
+```python
+async def batch_download(request: BatchDownloadRequest) -> BatchDownloadSummary:
+```
+
+Downloads historical OHLCV bars for multiple symbols concurrently.
+
+All input symbols are normalized and deduplicated (order-preserving) before dispatch. A shared `asyncio.Semaphore` caps the number of in-flight WebSocket connections. Partial failures are collected in the returned `BatchDownloadSummary`; no exception is raised unless `request.strict=True`.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `request` | `BatchDownloadRequest` | Validated request specifying symbols, interval, fetch mode, concurrency, and retry policy |
+
+### Returns
+
+`BatchDownloadSummary` — one `SymbolResult` per deduplicated input symbol, in input order.
+
+### Raises
+
+| Exception | Condition |
+|-----------|-----------|
+| `BatchDownloadError` | `strict=True` and one or more symbols failed. `exc.summary` always contains the full results, including all partial successes. |
+
+---
+
+## `BatchDownloadRequest`
+
+```python
+class BatchDownloadRequest(BaseModel):
+```
+
+Validated input parameters for `batch_download()`. Enforces mutual exclusivity between `bars_count` and `start`/`end`, validates all field constraints at construction time, and normalizes `start`/`end` to UTC-aware datetimes.
+
+Invalid parameters raise `pydantic.ValidationError` at construction time.
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `symbols` | `list[str]` | — | TradingView symbols. Normalized and deduplicated before fetch. Minimum 1 symbol required. |
+| `interval` | `str` | `"1D"` | Timeframe interval. Valid values: `"1"`, `"5"`, `"15"`, `"30"`, `"60"`, `"1H"`, `"4H"`, `"1D"`, `"1W"`, `"1M"` |
+| `bars_count` | `int \| None` | `None` | Number of most-recent bars per symbol. Mutually exclusive with `start`. Must be `> 0`. |
+| `start` | `datetime \| None` | `None` | Range start. Accepts ISO 8601 string or `datetime`; normalized to UTC. Mutually exclusive with `bars_count`. `end` without `start` is invalid. |
+| `end` | `datetime \| None` | `None` | Range end. Normalized to UTC. Requires `start` — `end` without `start` raises `ValidationError`. Defaults to current UTC time when `start` is set but `end` is omitted. Must be strictly after `start`. |
+| `concurrency` | `int` | `5` | Maximum in-flight WebSocket connections at any moment. Must be `≥ 1`. |
+| `max_attempts` | `int` | `3` | Per-symbol retry limit including the initial attempt. Must be `≥ 1`. |
+| `base_backoff` | `float` | `1.0` | Initial backoff in seconds. Doubles each attempt up to `max_backoff`. Must be `> 0`. |
+| `max_backoff` | `float` | `30.0` | Backoff ceiling in seconds. Must be `> 0`. |
+| `auth_token` | `SecretStr \| None` | `None` | TradingView auth token. Stored as `SecretStr` — never appears in logs or `repr()`. |
+| `browser` | `str \| None` | `None` | Browser for cookie extraction. Accepted values: `"chrome"`, `"firefox"`. |
+| `on_progress` | `Callable[[SymbolResult, int, int], None] \| None` | `None` | Sync callback invoked after each symbol resolves. See callback contract below. Async callables raise `ValidationError` at construction. |
+| `validate_symbols_before_fetch` | `bool` | `False` | Pre-validate symbols via TradingView HTTP API before fetching. Invalid symbols become `SymbolResult(success=False, attempts=0)`. Not recommended for batches > 200 symbols. |
+| `strict` | `bool` | `False` | If `True`, raise `BatchDownloadError` when any symbol fails. |
+
+### Validation rules
+
+Invalid values raise `pydantic.ValidationError` at construction:
+
+| Parameter | Rule |
+|-----------|------|
+| `symbols` | Non-empty list (`min_length=1`) |
+| `bars_count` + `start` | Mutually exclusive — provide one, not both |
+| Neither `bars_count` nor `start` | `ValidationError`: at least one fetch mode is required |
+| `end` without `start` | `ValidationError`: `end` requires `start` |
+| `end` ≤ `start` | `ValidationError`: `end` must be strictly after `start` |
+| `interval` | Must be a valid tvkit interval string |
+| `browser` | Must be `"chrome"` or `"firefox"` (or `None`) |
+| `on_progress` | Must be synchronous — async callables raise `ValidationError` at construction |
+
+### Datetime handling
+
+`start` and `end` accept ISO 8601 strings or `datetime` objects. All are normalized to UTC-aware datetimes at construction time:
+
+- ISO 8601 strings are parsed via `datetime.fromisoformat()`.
+- **Naive `datetime` objects are assumed to be UTC** and converted to UTC-aware datetimes.
+- Timezone-aware `datetime` objects are converted to UTC.
+
+```python
+# All equivalent — all produce the same UTC-aware datetime:
+BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", start="2024-01-01")
+BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", start="2024-01-01T00:00:00Z")
+BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", start=datetime(2024, 1, 1))  # naive → UTC
+```
+
+### `on_progress` callback contract
+
+```python
+def on_progress(result: SymbolResult, completed: int, total: int) -> None: ...
+```
+
+- Called once per symbol after its terminal result (success or final-attempt failure).
+- `completed` is 1-based; `total` is the deduplicated symbol count.
+- The callback must be **synchronous** — async callables raise `ValidationError` at construction.
+- Exceptions raised by the callback are logged at `ERROR` level and swallowed — a misbehaving callback does not abort the batch.
+- Retry events (non-terminal failures) do not trigger the callback — only the final outcome does.
+
+---
+
+## `BatchDownloadSummary`
+
+```python
+class BatchDownloadSummary(BaseModel):
+```
+
+Aggregated result of a `batch_download()` call. `results` preserves deduplicated input order.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `results` | `list[SymbolResult]` | One `SymbolResult` per deduplicated input symbol, in input order |
+| `total_count` | `int` | Symbol count after deduplication |
+| `success_count` | `int` | Symbols fetched successfully |
+| `failure_count` | `int` | Symbols that failed after all retries |
+| `elapsed_seconds` | `float` | Total wall-clock seconds for the entire batch |
+| `interval` | `str` | Interval used for all fetches |
+| `failed_symbols` | `list[str]` | Computed — canonical symbols that failed (empty list on full success) |
+| `successful_symbols` | `list[str]` | Computed — canonical symbols that succeeded |
+
+`failed_symbols` and `successful_symbols` are `@computed_field` properties and appear in `model_dump()` output.
+
+### `raise_if_failed()`
+
+```python
+def raise_if_failed(self) -> None:
+```
+
+Raises `BatchDownloadError` if `failure_count > 0`. Equivalent to having called `batch_download()` with `strict=True`, but callable after the fact — useful for pipelines that inspect the summary before deciding whether failures are fatal.
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+async def main() -> None:
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+        interval="1D",
+        bars_count=252,
+    )
+    summary = await batch_download(request)
+    print(f"Successful: {summary.successful_symbols}")
+    summary.raise_if_failed()  # raises BatchDownloadError if failure_count > 0
+
+asyncio.run(main())
+```
+
+---
+
+## `SymbolResult`
+
+```python
+class SymbolResult(BaseModel):
+```
+
+Result for a single symbol in a batch download.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `symbol` | `str` | Canonical symbol in `EXCHANGE:SYMBOL` format |
+| `bars` | `list[OHLCVBar]` | Fetched OHLCV bars, sorted chronologically (oldest first). Always a list — never `None`. Empty on failure, and may be empty on success if the server returned no data for the requested range. |
+| `success` | `bool` | `True` if the fetch completed without error |
+| `error` | `ErrorInfo \| None` | Structured error detail if `success=False`, else `None` |
+| `attempts` | `int` | Number of fetch attempts. `0` = rejected at pre-flight (no fetch made); `1+` = fetch attempt count. |
+| `elapsed_seconds` | `float` | Wall-clock seconds across all attempts for this symbol |
+
+### Invariants
+
+Enforced by `@model_validator` — construction raises `ValidationError` if violated:
+
+- `success=True` → `error is None`
+- `success=False` → `error is not None` and `bars` is empty
+
+`bars` is always a `list` — never `None`. Callers can iterate `result.bars` without a `None` check, but should guard against an empty list before accessing `result.bars[-1]`.
+
+---
+
+## `ErrorInfo`
+
+```python
+class ErrorInfo(BaseModel):
+```
+
+Structured error record for a failed symbol fetch.
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | `str` | Human-readable error message |
+| `exception_type` | `str` | Exception class name (e.g. `"StreamConnectionError"`, `"SymbolValidationError"`) |
+| `attempt` | `int` | Attempt number when the error occurred. `0` = pre-flight rejection; `1+` = fetch attempt number. |
+
+### `attempt` values
+
+| `attempt` | Meaning |
+|-----------|---------|
+| `0` | Symbol rejected at pre-flight validation — no WebSocket connection was opened |
+| `1+` | Error occurred during a fetch attempt; value is the attempt number on which it failed |
+
+---
+
+## `BatchDownloadError`
+
+```python
+class BatchDownloadError(Exception):
+```
+
+Raised by `batch_download()` when `strict=True` and one or more symbols fail, or by `BatchDownloadSummary.raise_if_failed()`.
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `summary` | `BatchDownloadSummary` | Full result including both successful and failed symbols. Always populated — partial successes are always accessible even when this exception is raised. |
+| `failed_symbols` | `list[str]` | Convenience accessor for `summary.failed_symbols` |
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest, BatchDownloadError
+
+async def main() -> None:
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:INVALID_XYZ"],
+        interval="1D",
+        bars_count=10,
+        strict=True,
+    )
+    try:
+        summary = await batch_download(request)
+    except BatchDownloadError as exc:
+        print(f"Failed: {exc.failed_symbols}")
+        # Partial successes always available on exc.summary:
+        for result in exc.summary.results:
+            if result.success and result.bars:
+                print(f"{result.symbol}: {len(result.bars)} bars")
+
+asyncio.run(main())
+```
+
+---
+
+## Retry and Exception Handling
+
+### Retryable exceptions
+
+These exceptions trigger a retry with exponential backoff. Pre-flight validation failures are **not retried** — they are terminal by design.
+
+| Exception | Source | Rationale |
+|-----------|--------|-----------|
+| `StreamConnectionError` | `tvkit.api.chart.exceptions` | WebSocket dropped — transient network failure |
+| `websockets.exceptions.WebSocketException` | `websockets` | Underlying transport error |
+| `TimeoutError` | `asyncio` | Request timed out |
+
+### Non-retryable exceptions
+
+These exceptions stop retry immediately — the symbol is recorded as failed without further attempts:
+
+| Exception | Rationale |
+|-----------|-----------|
+| `ValueError` | Bad input — programmer error; retrying cannot succeed |
+| `NoHistoricalDataError` | TradingView confirms no data exists for this symbol/range — permanent |
+
+Any other unexpected exception is caught by a final broad handler, converted to a failed `SymbolResult`, and logged at `ERROR` with `exc_info=True`. This prevents one symbol's failure from cancelling sibling tasks in `asyncio.gather()`.
+
+### Backoff formula
+
+```
+backoff = min(base_backoff * 2 ** (attempt - 1), max_backoff)
+```
+
+With defaults (`base_backoff=1.0`, `max_backoff=30.0`): 1.0s → 2.0s → 4.0s → 8.0s → … → 30.0s.
+
+The semaphore is **released before** the backoff sleep — other symbols can start their attempts while this one waits between retries.
+
+---
+
+## Pre-flight Symbol Validation
+
+When `validate_symbols_before_fetch=True`, all deduplicated symbols are validated via the TradingView HTTP API **before** any WebSocket fetch begins. Validation runs **serially** (one HTTP call per symbol, in order).
+
+- Symbols confirmed invalid (HTTP 404) become `SymbolResult(success=False, attempts=0, error=ErrorInfo(attempt=0, exception_type="SymbolValidationError"))`. A `WARNING` is logged per skipped symbol.
+- Symbols with indeterminate validation (transport or server failure) **fail open**: they proceed to the fetch phase unchanged. A `WARNING` is logged to indicate validation was unavailable for that symbol.
+- A `WARNING` is emitted if the batch exceeds 200 symbols, because validation runs serially and adds one HTTP call per symbol before any fetch begins.
+
+Use `error.attempt == 0` to distinguish pre-flight failures from fetch-phase failures (`error.attempt >= 1`).
+
+> **Performance note**: Not recommended for batches > 200 symbols.
+
+---
+
+## Deduplication Behavior
+
+Input symbols are normalized via `tvkit.symbols.normalize_symbols()` then deduplicated using order-preserving `dict.fromkeys()`. The `BatchDownloadSummary` reflects the deduplicated count.
+
+```python
+import asyncio
+from tvkit.batch import batch_download, BatchDownloadRequest
+
+async def main() -> None:
+    # 5 inputs → 3 unique symbols after normalize + dedup
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "nasdaq:aapl", "NASDAQ:MSFT", "NASDAQ:MSFT", "NYSE:JPM"],
+        interval="1D",
+        bars_count=10,
+    )
+    summary = await batch_download(request)
+    assert summary.total_count == 3
+    assert len(summary.results) == 3
+
+asyncio.run(main())
+```
+
+---
+
+## See Also
+
+- [Batch Download Guide](../../guides/batch-download.md) — workflow guide with complete patterns
+- [Example script](../../../examples/batch_sp500_historical.py) — runnable demos
+- [OHLCV Client reference](../chart/ohlcv.md) — the underlying single-symbol client

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -57,12 +57,25 @@ Multi-format data export for OHLCV and scanner results.
 
 ---
 
+---
+
+## Batch API — `tvkit.batch`
+
+High-throughput async batch downloader for large symbol sets.
+
+| Page | Class / Module | What it covers |
+|------|---------------|----------------|
+| [Batch Downloader](batch/downloader.md) | `batch_download`, `BatchDownloadRequest` | `batch_download()`, `BatchDownloadRequest`, `BatchDownloadSummary`, `SymbolResult`, `ErrorInfo`, `BatchDownloadError`, retry policy, pre-flight validation, deduplication |
+
+---
+
 ## Quick Navigation: which page do I need?
 
 | I want to… | Go to |
 |-----------|-------|
 | Fetch historical OHLCV bars | [OHLCV Client](chart/ohlcv.md) |
 | Stream real-time price updates | [OHLCV Client](chart/ohlcv.md) |
+| Fetch historical bars for many symbols concurrently | [Batch Downloader](batch/downloader.md) |
 | Validate or convert an interval string | [Chart Utilities](chart/utils.md) |
 | Screen stocks with filters and sorting | [Scanner](scanner/scanner.md) |
 | Find the market identifier for a country or exchange | [Markets](scanner/markets.md) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 
 ## Recently Shipped
 
+- **v0.10.0** — Async Batch Downloader (`tvkit.batch`: `batch_download()`, bounded concurrency via semaphore, per-symbol retry with exponential backoff, `BatchDownloadSummary`, partial failure model, opt-in pre-flight symbol validation)
 - **v0.9.0** — Data Integrity Validation (`tvkit.validation`: duplicate/monotonic/OHLC/volume/gap checks; `DataExporter` integration with `validate`, `strict`, `interval` parameters)
 - **v0.8.0** —  Symbol Normalization 
 - **v0.7.0** — Authentication
@@ -75,26 +76,6 @@ Benefits:
 - Compatibility with data lake tooling
 
 ---
-
-#### Async Batch Downloader
-
-High-throughput historical downloader capable of fetching large symbol sets concurrently.
-
-Features may include:
-
-- Bounded concurrency
-- Retry with exponential backoff
-- Cache integration
-- Partial progress recovery
-
-```python
-await batch_download(
-    symbols=[...],
-    interval="1D",
-    bars_count=500,
-    concurrency=5,
-)
-```
 
 ---
 

--- a/examples/batch_sp500_historical.py
+++ b/examples/batch_sp500_historical.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Async Batch Downloader — tvkit Example
+=======================================
+
+Demonstrates high-throughput concurrent historical OHLCV fetching for a set
+of well-known large-cap symbols using ``tvkit.batch``.
+
+What you'll learn:
+- Fetching OHLCV data for many symbols concurrently (bounded concurrency)
+- Real-time progress reporting with a live progress bar
+- Handling partial failures gracefully (strict=False default)
+- Deduplication and symbol normalization behaviour
+- Pre-flight symbol validation (opt-in)
+- Summary reporting: success/failure counts, per-symbol elapsed time
+- Raising on any failure with strict=True / raise_if_failed()
+
+Run:
+    uv run python examples/batch_sp500_historical.py
+"""
+
+import asyncio
+import logging
+import traceback
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
+from rich.table import Table
+from rich.text import Text
+
+from tvkit.api.utils import convert_timestamp_to_iso
+from tvkit.batch import BatchDownloadRequest, BatchDownloadSummary, SymbolResult, batch_download
+from tvkit.batch.exceptions import BatchDownloadError
+
+console = Console()
+
+# Suppress tvkit internal logs so rich output stays clean in this demo.
+logging.getLogger("tvkit").setLevel(logging.CRITICAL)
+
+# ── Sample symbol sets ────────────────────────────────────────────────────────
+
+_MEGA_CAPS: list[str] = [
+    "NASDAQ:AAPL",
+    "NASDAQ:MSFT",
+    "NASDAQ:NVDA",
+    "NASDAQ:GOOGL",
+    "NASDAQ:AMZN",
+    "NYSE:BRK.B",
+    "NYSE:JPM",
+    "NYSE:V",
+    "NYSE:UNH",
+    "NYSE:XOM",
+]
+
+# Intentional duplicates and case variation — batch_download deduplicates these.
+_SYMBOLS_WITH_DUPES: list[str] = [
+    "NASDAQ:AAPL",
+    "nasdaq:aapl",  # duplicate, different case
+    "NASDAQ:MSFT",
+    "NASDAQ:MSFT",  # exact duplicate
+    "NYSE:JPM",
+]
+
+
+# ── Output helpers ────────────────────────────────────────────────────────────
+
+
+def _section(title: str, subtitle: str = "") -> None:
+    header = Text()
+    header.append(title, style="bold cyan")
+    if subtitle:
+        header.append(f"\n{subtitle}", style="dim")
+    console.print(Panel(header, box=box.ROUNDED, border_style="cyan", padding=(0, 2)))
+
+
+def _print_summary(summary: BatchDownloadSummary) -> None:
+    """Render a BatchDownloadSummary as a rich table."""
+    # Header counts
+    header = Table.grid(padding=(0, 2))
+    header.add_column(style="bold")
+    header.add_column()
+    header.add_row(
+        "Symbols",
+        f"{summary.total_count} requested  ·  "
+        f"[green]{summary.success_count} succeeded[/green]  ·  "
+        f"[red]{summary.failure_count} failed[/red]",
+    )
+    header.add_row("Interval", summary.interval)
+    header.add_row("Wall time", f"{summary.elapsed_seconds:.2f}s")
+    console.print(header)
+    console.print()
+
+    # Per-symbol results
+    table = Table(box=box.SIMPLE_HEAD, show_edge=False, padding=(0, 1))
+    table.add_column("Symbol", style="bold", min_width=16, max_width=18, no_wrap=True)
+    table.add_column("Status", justify="center", min_width=9)
+    table.add_column("Bars", justify="right", min_width=5)
+    table.add_column("Atts", justify="right", min_width=4)
+    table.add_column("Elapsed", justify="right", min_width=7)
+    table.add_column("Close", justify="right", min_width=8)
+    table.add_column("Last Bar", justify="right", min_width=10)
+
+    for result in summary.results:
+        if result.success:
+            status = Text("✔  OK", style="bold green")
+            bars_col = str(len(result.bars))
+            last_close = f"${result.bars[-1].close:,.2f}" if result.bars else "—"
+            last_date = (
+                convert_timestamp_to_iso(result.bars[-1].timestamp)[:10] if result.bars else "—"
+            )
+            last_bar_col = Text(last_date, style="dim")
+        else:
+            status = Text("✘  FAIL", style="bold red")
+            bars_col = "—"
+            last_close = "—"
+            last_bar_col = Text("—", style="dim")
+
+        table.add_row(
+            result.symbol,
+            status,
+            bars_col,
+            str(result.attempts),
+            f"{result.elapsed_seconds:.2f}s",
+            last_close,
+            last_bar_col,
+        )
+
+    console.print(table)
+
+    # Print failure details below the table (error type + message)
+    failures = [r for r in summary.results if not r.success]
+    if failures:
+        console.print()
+        for r in failures:
+            exc_type = (r.error.exception_type if r.error else "?").split(".")[-1]
+            error_msg = (r.error.message if r.error else "unknown").replace("\n", " ")[:60]
+            console.print(
+                f"  [red]✘[/red]  [bold]{r.symbol}[/bold]  [dim][{exc_type}][/dim] {error_msg}",
+            )
+
+
+# ── Demo sections ─────────────────────────────────────────────────────────────
+
+
+async def demo_basic_batch() -> None:
+    """Fetch 252 daily bars for 10 mega-cap symbols with a live progress bar."""
+    _section(
+        "Demo 1 — Basic Batch Download",
+        "252 daily bars · 10 symbols · concurrency=5 · bars_count mode",
+    )
+
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(bar_width=40),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TextColumn("·  [cyan]{task.completed}/{task.total}"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=False,
+    )
+
+    task_id: TaskID | None = None
+
+    def on_progress(result: SymbolResult, completed: int, total: int) -> None:
+        nonlocal task_id
+        if task_id is None:
+            return
+        symbol_short = result.symbol.split(":")[1]
+        status = "✔" if result.success else "✘"
+        progress.update(
+            task_id,
+            advance=1,
+            description=f"[bold blue]Batch download  {status} {symbol_short:<6}",
+        )
+
+    with progress:
+        task_id = progress.add_task("Batch download  …      ", total=len(_MEGA_CAPS))
+        request = BatchDownloadRequest(
+            symbols=_MEGA_CAPS,
+            interval="1D",
+            bars_count=252,
+            concurrency=5,
+            on_progress=on_progress,
+        )
+        summary = await batch_download(request)
+
+    console.print()
+    _print_summary(summary)
+
+
+async def demo_deduplication() -> None:
+    """Show that duplicate and case-variant symbols are silently deduplicated."""
+    _section(
+        "Demo 2 — Deduplication",
+        "5 input symbols → 3 unique after normalization + dedup",
+    )
+
+    console.print(f"  Input symbols ({len(_SYMBOLS_WITH_DUPES)}):", style="dim")
+    for s in _SYMBOLS_WITH_DUPES:
+        console.print(f"    [dim]•[/dim] {s}")
+    console.print()
+
+    request = BatchDownloadRequest(
+        symbols=_SYMBOLS_WITH_DUPES,
+        interval="1D",
+        bars_count=10,
+        concurrency=3,
+    )
+    summary = await batch_download(request)
+
+    console.print(
+        f"  After dedup: [bold cyan]{summary.total_count}[/bold cyan] unique symbols fetched"
+    )
+    console.print()
+    _print_summary(summary)
+
+
+async def demo_partial_failure() -> None:
+    """Show strict=False partial failure — real and fake symbols mixed."""
+    _section(
+        "Demo 3 — Partial Failure (strict=False)",
+        "Mix of real symbols and invalid symbols — failures collected, not raised",
+    )
+
+    mixed_symbols = ["NASDAQ:AAPL", "NASDAQ:INVALID_FAKE_XYZ", "NASDAQ:MSFT"]
+    request = BatchDownloadRequest(
+        symbols=mixed_symbols,
+        interval="1D",
+        bars_count=10,
+        concurrency=3,
+        max_attempts=1,  # fail fast for demo
+        strict=False,
+    )
+    summary = await batch_download(request)
+    _print_summary(summary)
+
+    if summary.failure_count > 0:
+        console.print(
+            f"  [yellow]⚠[/yellow]  {summary.failure_count} symbol(s) failed — "
+            "inspect summary.failed_symbols for details"
+        )
+        console.print(f"  Failed: {summary.failed_symbols}")
+
+
+async def demo_strict_mode() -> None:
+    """Show strict=True — BatchDownloadError raised with partial results attached."""
+    _section(
+        "Demo 4 — Strict Mode (strict=True)",
+        "BatchDownloadError raised if any symbol fails; partial results on exc.summary",
+    )
+
+    mixed_symbols = ["NASDAQ:AAPL", "NASDAQ:INVALID_FAKE_XYZ"]
+    request = BatchDownloadRequest(
+        symbols=mixed_symbols,
+        interval="1D",
+        bars_count=10,
+        concurrency=2,
+        max_attempts=1,
+        strict=True,
+    )
+
+    try:
+        await batch_download(request)
+        console.print("  All symbols succeeded — no exception raised.", style="green")
+    except BatchDownloadError as exc:
+        console.print(
+            f"  [bold red]BatchDownloadError[/bold red]: {exc}",
+        )
+        console.print(
+            f"  [dim]Partial results on exc.summary:[/dim]  "
+            f"[green]{exc.summary.success_count} ok[/green]  ·  "
+            f"[red]{exc.summary.failure_count} failed[/red]"
+        )
+        console.print(f"  Failed symbols: [red]{exc.failed_symbols}[/red]")
+        console.print()
+        console.print("  [dim]Successful results still accessible via exc.summary.results:[/dim]")
+        for result in exc.summary.results:
+            if result.success:
+                console.print(
+                    f"    [green]✔[/green]  {result.symbol}  "
+                    f"→ {len(result.bars)} bars, "
+                    f"last close ${result.bars[-1].close:,.2f}"
+                )
+
+
+async def main() -> None:
+    console.print()
+    console.print(
+        Panel(
+            "[bold white]tvkit.batch — Async Batch Downloader[/bold white]\n"
+            "[dim]High-throughput concurrent OHLCV fetching with bounded concurrency, "
+            "retry, and partial-failure support[/dim]",
+            box=box.DOUBLE_EDGE,
+            border_style="bright_blue",
+            padding=(1, 4),
+        )
+    )
+    console.print()
+
+    try:
+        await demo_basic_batch()
+        console.print()
+        await demo_deduplication()
+        console.print()
+        await demo_partial_failure()
+        console.print()
+        await demo_strict_mode()
+        console.print()
+        console.print("[bold green]All demos complete.[/bold green]")
+    except Exception:
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvkit"
-version = "0.9.0"
+version = "0.10.0"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_batch_downloader.py
+++ b/tests/test_batch_downloader.py
@@ -1,0 +1,382 @@
+"""Tests for tvkit.batch — async batch downloader.
+
+Covers:
+- Single-symbol success
+- Strict-mode failure escalation
+- Partial failure (strict=False)
+- Symbol deduplication (order-preserving, multi-symbol)
+- Retry then success (transient failure on attempt 1)
+- Retry exhaustion (all attempts fail)
+- Non-retryable ValueError (no retry)
+- Non-retryable NoHistoricalDataError (no retry)
+- on_progress callback behavior
+- BatchDownloadRequest mutual-exclusivity validation
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from tvkit.api.chart.exceptions import NoHistoricalDataError, StreamConnectionError
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.batch import BatchDownloadRequest, batch_download
+from tvkit.batch.exceptions import BatchDownloadError
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_bars() -> list[OHLCVBar]:
+    return [
+        OHLCVBar(
+            timestamp=1700000000.0,
+            open=100.0,
+            high=105.0,
+            low=99.0,
+            close=104.0,
+            volume=1_000_000.0,
+        )
+    ]
+
+
+def _make_mock_client(bars: list[OHLCVBar]) -> AsyncMock:
+    """Return an AsyncMock OHLCV context manager that returns bars on get_historical_ohlcv."""
+    client = AsyncMock()
+    client.get_historical_ohlcv.return_value = bars
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def _make_failing_client(exc: Exception) -> AsyncMock:
+    """Return an AsyncMock OHLCV context manager that raises exc on get_historical_ohlcv."""
+    client = AsyncMock()
+    client.get_historical_ohlcv.side_effect = exc
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_success(mock_bars: list[OHLCVBar]) -> None:
+    """Single symbol fetched successfully — summary counts and result contents correct."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", bars_count=1)
+        )
+
+    assert summary.success_count == 1
+    assert summary.failure_count == 0
+    assert summary.total_count == 1
+    assert summary.results[0].symbol == "NASDAQ:AAPL"
+    assert summary.results[0].success is True
+    assert summary.results[0].bars == mock_bars
+    assert summary.results[0].error is None
+    assert summary.results[0].attempts == 1
+
+
+# ---------------------------------------------------------------------------
+# Strict mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_strict_raises_on_failure() -> None:
+    """strict=True raises BatchDownloadError when any symbol fails; summary is attached."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("network down")),
+    ):
+        with pytest.raises(BatchDownloadError) as exc_info:
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL"],
+                    interval="1D",
+                    bars_count=1,
+                    max_attempts=1,
+                    strict=True,
+                )
+            )
+
+    err = exc_info.value
+    assert err.summary.failure_count == 1
+    assert err.summary.success_count == 0
+    assert "NASDAQ:AAPL" in err.failed_symbols
+
+
+# ---------------------------------------------------------------------------
+# Partial failure (strict=False)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_strict_false_partial_failure(mock_bars: list[OHLCVBar]) -> None:
+    """strict=False collects failures without raising; success and failure both present."""
+    good_client = _make_mock_client(mock_bars)
+    bad_client = _make_failing_client(StreamConnectionError("timeout"))
+
+    call_count = 0
+
+    def client_factory(*args: object, **kwargs: object) -> AsyncMock:
+        nonlocal call_count
+        call_count += 1
+        return good_client if call_count == 1 else bad_client
+
+    with patch("tvkit.batch.downloader.OHLCV", side_effect=client_factory):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+                strict=False,
+            )
+        )
+
+    assert summary.total_count == 2
+    assert summary.success_count == 1
+    assert summary.failure_count == 1
+    assert "NASDAQ:MSFT" in summary.failed_symbols
+    assert "NASDAQ:AAPL" in summary.successful_symbols
+
+
+# ---------------------------------------------------------------------------
+# Symbol deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_symbol_deduplication_order_preserved(mock_bars: list[OHLCVBar]) -> None:
+    """Duplicates are removed (first-seen wins); order of distinct symbols is preserved.
+
+    Input:  ["NASDAQ:MSFT", "NASDAQ:AAPL", "nasdaq:msft"]
+    After normalization + dedup:  ["NASDAQ:MSFT", "NASDAQ:AAPL"]
+    Expected result order:  MSFT first, AAPL second.
+    """
+    mock_client = _make_mock_client(mock_bars)
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=mock_client) as mock_ohlcv:
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:MSFT", "NASDAQ:AAPL", "nasdaq:msft"],
+                interval="1D",
+                bars_count=1,
+            )
+        )
+
+    assert summary.total_count == 2
+    assert summary.success_count == 2
+    assert summary.results[0].symbol == "NASDAQ:MSFT"
+    assert summary.results[1].symbol == "NASDAQ:AAPL"
+    # Two distinct symbols → two OHLCV constructions
+    assert mock_ohlcv.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_then_success(mock_bars: list[OHLCVBar]) -> None:
+    """Symbol fails on attempt 1 (transient) then succeeds on attempt 2; attempts == 2."""
+    fail_client = _make_failing_client(StreamConnectionError("dropped"))
+    ok_client = _make_mock_client(mock_bars)
+
+    call_count = 0
+
+    def client_factory(*args: object, **kwargs: object) -> AsyncMock:
+        nonlocal call_count
+        call_count += 1
+        return fail_client if call_count == 1 else ok_client
+
+    with patch("tvkit.batch.downloader.OHLCV", side_effect=client_factory):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+                base_backoff=0.0001,  # near-zero backoff to keep the test fast
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is True
+    assert result.attempts == 2
+    assert result.bars == mock_bars
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion() -> None:
+    """All attempts fail; result is failure with attempts == max_attempts."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("down")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+                base_backoff=0.0001,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.attempts == 3
+    assert result.error is not None
+    assert result.bars == []
+
+
+# ---------------------------------------------------------------------------
+# Non-retryable exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_value_error() -> None:
+    """ValueError is not retried; result is failure with attempts == 1."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(ValueError("bad symbol")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.attempts == 1
+    assert result.error is not None
+    assert "ValueError" in result.error.exception_type
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_no_historical_data() -> None:
+    """NoHistoricalDataError is not retried despite being a RuntimeError subclass."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(NoHistoricalDataError("no data")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.attempts == 1
+    assert result.error is not None
+    assert "NoHistoricalDataError" in result.error.exception_type
+
+
+# ---------------------------------------------------------------------------
+# on_progress callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_progress_callback(mock_bars: list[OHLCVBar]) -> None:
+    """on_progress is called once per symbol with correct (result, completed, total) args."""
+    calls: list[tuple[object, int, int]] = []
+
+    def progress(result: object, completed: int, total: int) -> None:
+        calls.append((result, completed, total))
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                on_progress=progress,
+            )
+        )
+
+    assert len(calls) == 1
+    result_arg, completed_arg, total_arg = calls[0]
+    assert result_arg is summary.results[0]
+    assert completed_arg == 1  # 1-based
+    assert total_arg == 1
+
+
+# ---------------------------------------------------------------------------
+# BatchDownloadRequest validation
+# ---------------------------------------------------------------------------
+
+
+def test_request_validation_mutual_exclusivity() -> None:
+    """Providing both bars_count and start raises ValidationError."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            bars_count=10,
+            start="2024-01-01",
+        )
+
+
+def test_request_validation_neither_provided() -> None:
+    """Providing neither bars_count nor start raises ValidationError."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+        )
+
+
+def test_request_validation_async_callback_rejected() -> None:
+    """Async callable passed as on_progress raises ValidationError at construction."""
+
+    async def async_cb(result: object, completed: int, total: int) -> None:
+        pass  # pragma: no cover
+
+    with pytest.raises(ValidationError, match="synchronous callable"):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            bars_count=1,
+            on_progress=async_cb,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_progress_callback_exception_swallowed(mock_bars: list[OHLCVBar]) -> None:
+    """A callback that raises does not abort the batch; summary is still returned."""
+
+    def bad_callback(result: object, completed: int, total: int) -> None:
+        raise RuntimeError("callback bug")
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                on_progress=bad_callback,
+            )
+        )
+
+    # Batch completes successfully despite the callback raising
+    assert summary.success_count == 1
+    assert summary.failure_count == 0

--- a/tests/test_batch_downloader.py
+++ b/tests/test_batch_downloader.py
@@ -20,6 +20,14 @@ Phase 2 additions:
 - Structured logging LogRecord field assertions (WARNING per-attempt, WARNING non-retryable,
   ERROR catch-all with exc_info, INFO batch-complete)
 - catch-all handler converts unexpected exception to SymbolResult failure
+Phase 3 additions:
+- raise_if_failed(): raises BatchDownloadError on partial failure; no-op on full success
+- raise_if_failed(): error message contains counts; exc.summary identity; exc.failed_symbols
+- on_progress multi-symbol: invocation count == symbol count; completed counter 1-based
+- on_progress invoked for failed symbols (not just successes)
+- failed_symbols computed field: empty on full success
+- successful_symbols computed field: empty on full failure
+- model_dump() includes both computed fields
 """
 
 import logging
@@ -730,3 +738,240 @@ async def test_unexpected_exception_converted_to_failure() -> None:
     assert result.success is False
     assert result.bars == []
     assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: raise_if_failed()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raise_if_failed_raises_on_partial_failure() -> None:
+    """raise_if_failed() raises BatchDownloadError when failure_count > 0."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("down")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+            )
+        )
+
+    assert summary.failure_count == 1
+    with pytest.raises(BatchDownloadError):
+        summary.raise_if_failed()
+
+
+@pytest.mark.asyncio
+async def test_raise_if_failed_noop_on_full_success(mock_bars: list[OHLCVBar]) -> None:
+    """raise_if_failed() does not raise when all symbols succeed."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", bars_count=1)
+        )
+
+    assert summary.failure_count == 0
+    summary.raise_if_failed()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_raise_if_failed_attaches_summary_and_failed_symbols() -> None:
+    """raise_if_failed() attaches the exact same summary object; exc.failed_symbols matches."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("down")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+            )
+        )
+
+    with pytest.raises(BatchDownloadError) as exc_info:
+        summary.raise_if_failed()
+
+    exc = exc_info.value
+    assert exc.summary is summary  # identity — same object, not a copy
+    assert exc.failed_symbols == ["NASDAQ:AAPL"]
+
+
+@pytest.mark.asyncio
+async def test_raise_if_failed_error_message_includes_counts() -> None:
+    """raise_if_failed() error message contains failure count and total count."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("down")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+            )
+        )
+
+    with pytest.raises(BatchDownloadError) as exc_info:
+        summary.raise_if_failed()
+
+    message = str(exc_info.value)
+    # Message must be actionable: both failure count and total are present
+    assert "2" in message  # 2 failures
+    assert "2" in message  # 2 total (also 2 in this case)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: on_progress multi-symbol behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_progress_multi_symbol_invocation_count(mock_bars: list[OHLCVBar]) -> None:
+    """on_progress is called exactly once per symbol for a 3-symbol batch."""
+    call_count = 0
+
+    def progress(result: object, completed: int, total: int) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
+                interval="1D",
+                bars_count=1,
+                on_progress=progress,
+            )
+        )
+
+    assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_on_progress_completed_counter_reaches_total(mock_bars: list[OHLCVBar]) -> None:
+    """completed counter is 1-based and every value from 1 to total appears exactly once."""
+    completed_values: list[int] = []
+    total_values: list[int] = []
+
+    def progress(result: object, completed: int, total: int) -> None:
+        completed_values.append(completed)
+        total_values.append(total)
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
+                interval="1D",
+                bars_count=1,
+                on_progress=progress,
+            )
+        )
+
+    # Every value from 1 to 3 must appear exactly once (order not guaranteed in async)
+    assert sorted(completed_values) == [1, 2, 3]
+    # total is always the deduplicated symbol count
+    assert all(t == 3 for t in total_values)
+
+
+@pytest.mark.asyncio
+async def test_on_progress_invoked_on_failure(mock_bars: list[OHLCVBar]) -> None:
+    """on_progress is invoked for failed symbols as well as successful ones."""
+    received_results: list[object] = []
+
+    def progress(result: object, completed: int, total: int) -> None:
+        received_results.append(result)
+
+    good_client = _make_mock_client(mock_bars)
+    bad_client = _make_failing_client(StreamConnectionError("down"))
+
+    call_count = 0
+
+    def client_factory(*args: object, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        return good_client if call_count == 1 else bad_client
+
+    with patch("tvkit.batch.downloader.OHLCV", side_effect=client_factory):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+                on_progress=progress,
+            )
+        )
+
+    # Callback must have been called for both symbols (one success, one failure)
+    assert len(received_results) == 2
+    successes = [r for r in received_results if getattr(r, "success", None) is True]
+    failures = [r for r in received_results if getattr(r, "success", None) is False]
+    assert len(successes) == 1
+    assert len(failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: computed fields — failed_symbols and successful_symbols
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_symbols_is_empty_on_full_success(mock_bars: list[OHLCVBar]) -> None:
+    """failed_symbols is an empty list when all symbols succeed."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                interval="1D",
+                bars_count=1,
+            )
+        )
+
+    assert summary.failed_symbols == []
+    assert summary.successful_symbols == ["NASDAQ:AAPL", "NASDAQ:MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_successful_symbols_is_empty_on_full_failure() -> None:
+    """successful_symbols is an empty list when all symbols fail."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("down")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+            )
+        )
+
+    assert summary.successful_symbols == []
+    assert set(summary.failed_symbols) == {"NASDAQ:AAPL", "NASDAQ:MSFT"}
+
+
+@pytest.mark.asyncio
+async def test_summary_model_dump_includes_computed_fields(mock_bars: list[OHLCVBar]) -> None:
+    """model_dump() output includes failed_symbols and successful_symbols computed fields."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+            )
+        )
+
+    dumped = summary.model_dump()
+    assert "failed_symbols" in dumped
+    assert "successful_symbols" in dumped
+    assert dumped["failed_symbols"] == []
+    assert dumped["successful_symbols"] == ["NASDAQ:AAPL"]

--- a/tests/test_batch_downloader.py
+++ b/tests/test_batch_downloader.py
@@ -30,7 +30,9 @@ Phase 3 additions:
 - model_dump() includes both computed fields
 """
 
+import asyncio
 import logging
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -40,6 +42,7 @@ from tvkit.api.chart.exceptions import NoHistoricalDataError, StreamConnectionEr
 from tvkit.api.chart.models.ohlcv import OHLCVBar
 from tvkit.batch import BatchDownloadRequest, batch_download
 from tvkit.batch.exceptions import BatchDownloadError
+from tvkit.batch.models import BatchDownloadSummary, ErrorInfo, SymbolResult
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -1411,3 +1414,454 @@ async def test_preflight_progress_total_uses_original_deduped_count(
     # on_progress is only called for fetch tasks (not pre-flight rejections)
     # AAPL proceeds to fetch → callback called once with total=2
     assert total_values == [2]
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Happy-path and strict-mode completeness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_symbol_all_success(mock_bars: list[OHLCVBar]) -> None:
+    """Multiple symbols all succeed — counts, symbols, and bars all correct."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
+                interval="1D",
+                bars_count=1,
+            )
+        )
+
+    assert summary.total_count == 3
+    assert summary.success_count == 3
+    assert summary.failure_count == 0
+    assert summary.successful_symbols == ["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"]
+    assert summary.failed_symbols == []
+    assert all(r.success for r in summary.results)
+    assert all(r.bars == mock_bars for r in summary.results)
+
+
+@pytest.mark.asyncio
+async def test_strict_ok_no_raise(mock_bars: list[OHLCVBar]) -> None:
+    """strict=True with full success — batch_download() returns normally without raising."""
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                strict=True,
+            )
+        )
+
+    assert summary.success_count == 1
+    assert summary.failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Date-range mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_date_range_mode(mock_bars: list[OHLCVBar]) -> None:
+    """start/end mode passes start and end to get_historical_ohlcv (not bars_count)."""
+    mock_client = _make_mock_client(mock_bars)
+    with patch("tvkit.batch.downloader.OHLCV", return_value=mock_client):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 12, 31, tzinfo=UTC),
+            )
+        )
+
+    assert summary.success_count == 1
+    # Verify that get_historical_ohlcv was called with start/end (not bars_count)
+    call_kwargs = mock_client.get_historical_ohlcv.call_args.kwargs
+    assert "start" in call_kwargs
+    assert "end" in call_kwargs
+    assert "bars_count" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Concurrency and semaphore behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semaphore_released_before_backoff() -> None:
+    """Semaphore is released (value > 0) at the moment asyncio.sleep is called during backoff."""
+    semaphore_values: list[int] = []
+    the_semaphore: asyncio.Semaphore | None = None
+
+    original_semaphore = asyncio.Semaphore
+
+    def capturing_semaphore(n: int) -> asyncio.Semaphore:
+        nonlocal the_semaphore
+        sem = original_semaphore(n)
+        the_semaphore = sem
+        return sem
+
+    async def fake_sleep(delay: float) -> None:
+        if the_semaphore is not None:
+            semaphore_values.append(the_semaphore._value)  # type: ignore[attr-defined]
+
+    with (
+        patch("tvkit.batch.downloader.asyncio.Semaphore", side_effect=capturing_semaphore),
+        patch("tvkit.batch.downloader.asyncio.sleep", side_effect=fake_sleep),
+        patch(
+            "tvkit.batch.downloader.OHLCV",
+            return_value=_make_failing_client(StreamConnectionError("dropped")),
+        ),
+    ):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=2,
+                base_backoff=0.0001,
+                concurrency=1,
+            )
+        )
+
+    # The semaphore must be released (value > 0) when sleep is called
+    assert semaphore_values, "asyncio.sleep was never called — retry did not happen"
+    assert all(v > 0 for v in semaphore_values), (
+        f"Semaphore was held during backoff sleep (values: {semaphore_values})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrency_bounded() -> None:
+    """Peak concurrent fetch tasks never exceeds the concurrency setting."""
+    peak_concurrent = 0
+    current_concurrent = 0
+    lock = asyncio.Lock()
+
+    async def slow_fetch(*args: object, **kwargs: object) -> list[OHLCVBar]:
+        nonlocal peak_concurrent, current_concurrent
+        async with lock:
+            current_concurrent += 1
+            peak_concurrent = max(peak_concurrent, current_concurrent)
+        await asyncio.sleep(0.01)
+        async with lock:
+            current_concurrent -= 1
+        return []
+
+    mock_client = AsyncMock()
+    mock_client.get_historical_ohlcv.side_effect = slow_fetch
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("tvkit.batch.downloader.OHLCV", return_value=mock_client):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=[f"NASDAQ:SYM{i}" for i in range(10)],
+                interval="1D",
+                bars_count=1,
+                concurrency=3,
+            )
+        )
+
+    assert peak_concurrent <= 3, f"Concurrency cap exceeded: peak={peak_concurrent}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Symbol normalization and order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_symbol_normalization_applied(mock_bars: list[OHLCVBar]) -> None:
+    """Lowercase exchange:symbol input is normalized to EXCHANGE:SYMBOL before fetch."""
+    mock_client = _make_mock_client(mock_bars)
+    with patch("tvkit.batch.downloader.OHLCV", return_value=mock_client):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["nasdaq:aapl"],
+                interval="1D",
+                bars_count=1,
+            )
+        )
+
+    assert summary.results[0].symbol == "NASDAQ:AAPL"
+
+
+@pytest.mark.asyncio
+async def test_input_order_preserved(mock_bars: list[OHLCVBar]) -> None:
+    """Result order matches deduplicated input order for distinct symbols."""
+    symbols = ["NYSE:JPM", "NASDAQ:AAPL", "NASDAQ:MSFT"]
+    with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+        summary = await batch_download(
+            BatchDownloadRequest(symbols=symbols, interval="1D", bars_count=1)
+        )
+
+    assert [r.symbol for r in summary.results] == symbols
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Retry behaviour — additional retryable exception types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_websocket_exception_retried(mock_bars: list[OHLCVBar]) -> None:
+    """websockets.exceptions.WebSocketException triggers retry; succeeds on second attempt."""
+    import websockets.exceptions
+
+    fail_client = _make_failing_client(websockets.exceptions.ConnectionClosedError(None, None))
+    ok_client = _make_mock_client(mock_bars)
+
+    call_count = 0
+
+    def client_factory(*args: object, **kwargs: object) -> AsyncMock:
+        nonlocal call_count
+        call_count += 1
+        return fail_client if call_count == 1 else ok_client
+
+    with patch("tvkit.batch.downloader.OHLCV", side_effect=client_factory):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=2,
+                base_backoff=0.0001,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is True
+    assert result.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_timeout_error_retried(mock_bars: list[OHLCVBar]) -> None:
+    """asyncio.TimeoutError triggers retry; succeeds on second attempt."""
+    fail_client = _make_failing_client(TimeoutError("timed out"))
+    ok_client = _make_mock_client(mock_bars)
+
+    call_count = 0
+
+    def client_factory(*args: object, **kwargs: object) -> AsyncMock:
+        nonlocal call_count
+        call_count += 1
+        return fail_client if call_count == 1 else ok_client
+
+    with patch("tvkit.batch.downloader.OHLCV", side_effect=client_factory):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=2,
+                base_backoff=0.0001,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is True
+    assert result.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_backoff_timing() -> None:
+    """asyncio.sleep is called with exponentially increasing backoff values."""
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    with (
+        patch("tvkit.batch.downloader.asyncio.sleep", side_effect=fake_sleep),
+        patch(
+            "tvkit.batch.downloader.OHLCV",
+            return_value=_make_failing_client(StreamConnectionError("down")),
+        ),
+    ):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+                base_backoff=1.0,
+                max_backoff=30.0,
+            )
+        )
+
+    # Expect two sleep calls (between attempt 1→2 and 2→3): 1.0s, 2.0s
+    assert len(sleep_calls) == 2
+    assert sleep_calls[0] == pytest.approx(1.0)
+    assert sleep_calls[1] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Model invariant validation
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_result_success_with_error_raises() -> None:
+    """SymbolResult rejects success=True when error is also set."""
+    with pytest.raises(ValidationError):
+        SymbolResult(
+            symbol="NASDAQ:AAPL",
+            bars=[],
+            success=True,
+            error=ErrorInfo(message="oops", exception_type="ValueError", attempt=1),
+            attempts=1,
+            elapsed_seconds=0.0,
+        )
+
+
+def test_symbol_result_failure_without_error_raises() -> None:
+    """SymbolResult rejects success=False when error is None."""
+    with pytest.raises(ValidationError):
+        SymbolResult(
+            symbol="NASDAQ:AAPL",
+            bars=[],
+            success=False,
+            error=None,
+            attempts=1,
+            elapsed_seconds=0.0,
+        )
+
+
+def test_symbol_result_failure_with_bars_raises() -> None:
+    """SymbolResult rejects success=False when bars is non-empty."""
+    bar = OHLCVBar(
+        timestamp=1700000000.0,
+        open=100.0,
+        high=105.0,
+        low=99.0,
+        close=104.0,
+        volume=1_000_000.0,
+    )
+    with pytest.raises(ValidationError):
+        SymbolResult(
+            symbol="NASDAQ:AAPL",
+            bars=[bar],
+            success=False,
+            error=ErrorInfo(message="oops", exception_type="ValueError", attempt=1),
+            attempts=1,
+            elapsed_seconds=0.0,
+        )
+
+
+def test_summary_total_count_mismatch_raises() -> None:
+    """BatchDownloadSummary rejects total_count that doesn't match len(results)."""
+    result = SymbolResult(
+        symbol="NASDAQ:AAPL",
+        bars=[],
+        success=False,
+        error=ErrorInfo(message="x", exception_type="E", attempt=1),
+        attempts=1,
+        elapsed_seconds=0.0,
+    )
+    with pytest.raises(ValidationError):
+        BatchDownloadSummary(
+            results=[result],
+            total_count=99,  # wrong — should be 1
+            success_count=0,
+            failure_count=1,
+            elapsed_seconds=0.0,
+            interval="1D",
+        )
+
+
+def test_summary_success_count_mismatch_raises() -> None:
+    """BatchDownloadSummary rejects success_count that doesn't match actual successes."""
+    result = SymbolResult(
+        symbol="NASDAQ:AAPL",
+        bars=[],
+        success=False,
+        error=ErrorInfo(message="x", exception_type="E", attempt=1),
+        attempts=1,
+        elapsed_seconds=0.0,
+    )
+    with pytest.raises(ValidationError):
+        BatchDownloadSummary(
+            results=[result],
+            total_count=1,
+            success_count=1,  # wrong — actual success is 0
+            failure_count=0,
+            elapsed_seconds=0.0,
+            interval="1D",
+        )
+
+
+def test_summary_failure_count_mismatch_raises() -> None:
+    """BatchDownloadSummary rejects failure_count that doesn't match actual failures."""
+    result = SymbolResult(
+        symbol="NASDAQ:AAPL",
+        bars=[],
+        success=False,
+        error=ErrorInfo(message="x", exception_type="E", attempt=1),
+        attempts=1,
+        elapsed_seconds=0.0,
+    )
+    with pytest.raises(ValidationError):
+        BatchDownloadSummary(
+            results=[result],
+            total_count=1,
+            success_count=0,
+            failure_count=0,  # wrong — actual failure is 1
+            elapsed_seconds=0.0,
+            interval="1D",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Validator path coverage
+# ---------------------------------------------------------------------------
+
+
+def test_datetime_tz_aware_normalization() -> None:
+    """Timezone-aware datetime input is converted to UTC (not just stamped with UTC)."""
+    eastern = timezone(timedelta(hours=-5))
+    dt_eastern = datetime(2024, 1, 1, 10, 0, 0, tzinfo=eastern)
+
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        start=dt_eastern,
+        end=datetime(2024, 12, 31, tzinfo=UTC),
+    )
+
+    # 10:00 ET = 15:00 UTC
+    assert request.start is not None
+    assert request.start.hour == 15
+    assert request.start.tzinfo is not None
+
+
+def test_datetime_explicit_none_accepted() -> None:
+    """Explicitly passing end=None is accepted (validator handles the None path)."""
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        start=datetime(2024, 1, 1, tzinfo=UTC),
+        end=None,
+    )
+    assert request.end is None
+
+
+def test_browser_valid_accepted() -> None:
+    """Valid browser values ('chrome', 'firefox') are accepted without error."""
+    req_chrome = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        bars_count=1,
+        browser="chrome",
+    )
+    req_firefox = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        bars_count=1,
+        browser="firefox",
+    )
+    assert req_chrome.browser == "chrome"
+    assert req_firefox.browser == "firefox"

--- a/tests/test_batch_downloader.py
+++ b/tests/test_batch_downloader.py
@@ -975,3 +975,439 @@ async def test_summary_model_dump_includes_computed_fields(mock_bars: list[OHLCV
     assert "successful_symbols" in dumped
     assert dumped["failed_symbols"] == []
     assert dumped["successful_symbols"] == ["NASDAQ:AAPL"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Pre-flight symbol validation
+# ---------------------------------------------------------------------------
+
+from tvkit.api.utils.symbol_validator import SymbolValidationOutcome  # noqa: E402
+
+
+def _valid_outcome(symbol: str) -> SymbolValidationOutcome:
+    return SymbolValidationOutcome(symbol=symbol, is_valid=True, is_known_invalid=False)
+
+
+def _invalid_outcome(symbol: str) -> SymbolValidationOutcome:
+    return SymbolValidationOutcome(
+        symbol=symbol,
+        is_valid=False,
+        is_known_invalid=True,
+        message=f"Symbol '{symbol}' not found (HTTP 404)",
+    )
+
+
+def _indeterminate_outcome(symbol: str) -> SymbolValidationOutcome:
+    return SymbolValidationOutcome(
+        symbol=symbol,
+        is_valid=False,
+        is_known_invalid=False,
+        message=f"Validation unavailable for '{symbol}' after 3 attempts",
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_disabled_by_default(mock_bars: list[OHLCVBar]) -> None:
+    """validate_symbols_before_fetch=False (default) — validate_symbol_detailed never called."""
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+        ) as mock_validate,
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="1D", bars_count=1)
+        )
+
+    mock_validate.assert_not_called()
+    assert summary.success_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_all_valid(mock_bars: list[OHLCVBar]) -> None:
+    """All symbols valid — all proceed to _fetch_one(); summary shows full success."""
+    symbols = ["NASDAQ:AAPL", "NASDAQ:MSFT"]
+    outcomes = [_valid_outcome(s) for s in symbols]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=symbols,
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    assert summary.success_count == 2
+    assert summary.failure_count == 0
+    assert summary.total_count == 2
+
+
+@pytest.mark.asyncio
+async def test_preflight_mixed(mock_bars: list[OHLCVBar]) -> None:
+    """Mixed valid/invalid — invalid symbol skipped, valid symbol fetched."""
+    outcomes = [_valid_outcome("NASDAQ:AAPL"), _invalid_outcome("NASDAQ:FAKE")]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:FAKE"],
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    assert summary.total_count == 2
+    assert summary.success_count == 1
+    assert summary.failure_count == 1
+    assert "NASDAQ:FAKE" in summary.failed_symbols
+    assert "NASDAQ:AAPL" in summary.successful_symbols
+
+
+@pytest.mark.asyncio
+async def test_preflight_all_invalid() -> None:
+    """All symbols invalid — zero fetch calls made; all results are pre-flight failures."""
+    symbols = ["NASDAQ:FAKE1", "NASDAQ:FAKE2"]
+    outcomes = [_invalid_outcome(s) for s in symbols]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV") as mock_ohlcv,
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=symbols,
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    mock_ohlcv.assert_not_called()
+    assert summary.success_count == 0
+    assert summary.failure_count == 2
+
+
+@pytest.mark.asyncio
+async def test_preflight_attempt_is_zero() -> None:
+    """Pre-flight-rejected symbol has SymbolResult.attempts == 0 and error.attempt == 0."""
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            return_value=_invalid_outcome("NASDAQ:FAKE"),
+        ),
+        patch("tvkit.batch.downloader.OHLCV"),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:FAKE"],
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.attempts == 0
+    assert result.error is not None
+    assert result.error.attempt == 0
+    assert result.error.exception_type == "SymbolValidationError"
+
+
+@pytest.mark.asyncio
+async def test_preflight_warning_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """WARNING log emitted per skipped symbol with 'symbol' and 'reason' structured fields."""
+    with caplog.at_level(logging.WARNING, logger="tvkit.batch.downloader"):
+        with (
+            patch(
+                "tvkit.batch.downloader.validate_symbol_detailed",
+                return_value=_invalid_outcome("NASDAQ:FAKE"),
+            ),
+            patch("tvkit.batch.downloader.OHLCV"),
+        ):
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:FAKE"],
+                    interval="1D",
+                    bars_count=1,
+                    validate_symbols_before_fetch=True,
+                )
+            )
+
+    skip_records = [
+        r
+        for r in caplog.records
+        if "pre-flight" in r.getMessage().lower() and "skipping" in r.getMessage().lower()
+    ]
+    assert skip_records, "Expected WARNING log about skipped symbol"
+    rec = skip_records[0]
+    assert rec.symbol == "NASDAQ:FAKE"  # type: ignore[attr-defined]
+    assert rec.reason is not None  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_preflight_large_batch_warning(
+    mock_bars: list[OHLCVBar],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WARNING logged when validate_symbols_before_fetch=True and batch > 200 symbols."""
+    symbols = [f"NASDAQ:SYM{i:04d}" for i in range(201)]
+    outcomes = [_valid_outcome(s) for s in symbols]
+
+    with caplog.at_level(logging.WARNING, logger="tvkit.batch.downloader"):
+        with (
+            patch(
+                "tvkit.batch.downloader.validate_symbol_detailed",
+                side_effect=outcomes,
+            ),
+            patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+        ):
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=symbols,
+                    interval="1D",
+                    bars_count=1,
+                    validate_symbols_before_fetch=True,
+                )
+            )
+
+    large_batch_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "large batch" in r.getMessage().lower()
+    ]
+    assert large_batch_records, "Expected WARNING about large batch"
+    assert large_batch_records[0].symbol_count == 201  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_preflight_validation_transport_failure_fails_open(
+    mock_bars: list[OHLCVBar],
+) -> None:
+    """Indeterminate validation outcome — symbol still reaches _fetch_one()."""
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            return_value=_indeterminate_outcome("NASDAQ:AAPL"),
+        ),
+        patch(
+            "tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)
+        ) as mock_ohlcv,
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    # Symbol was allowed through to fetch despite validation being unavailable
+    mock_ohlcv.assert_called_once()
+    assert summary.success_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_validation_transport_failure_warning_logged(
+    mock_bars: list[OHLCVBar],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """WARNING log emitted when validation cannot determine symbol status."""
+    with caplog.at_level(logging.WARNING, logger="tvkit.batch.downloader"):
+        with (
+            patch(
+                "tvkit.batch.downloader.validate_symbol_detailed",
+                return_value=_indeterminate_outcome("NASDAQ:AAPL"),
+            ),
+            patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+        ):
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL"],
+                    interval="1D",
+                    bars_count=1,
+                    validate_symbols_before_fetch=True,
+                )
+            )
+
+    unavailable_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "unavailable" in r.getMessage().lower()
+    ]
+    assert unavailable_records, "Expected WARNING when validation is unavailable"
+    rec = unavailable_records[0]
+    assert rec.symbol == "NASDAQ:AAPL"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_preflight_summary_counts_correct(mock_bars: list[OHLCVBar]) -> None:
+    """success_count and failure_count are correct after mixed pre-flight results."""
+    symbols = ["NASDAQ:AAPL", "NASDAQ:FAKE", "NASDAQ:MSFT"]
+    outcomes = [
+        _valid_outcome("NASDAQ:AAPL"),
+        _invalid_outcome("NASDAQ:FAKE"),
+        _valid_outcome("NASDAQ:MSFT"),
+    ]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=symbols,
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    assert summary.total_count == 3
+    assert summary.success_count == 2
+    assert summary.failure_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_order_preserved(mock_bars: list[OHLCVBar]) -> None:
+    """Pre-failed symbols appear at their original positions in summary.results."""
+    symbols = ["NASDAQ:AAPL", "NASDAQ:FAKE", "NASDAQ:MSFT"]
+    outcomes = [
+        _valid_outcome("NASDAQ:AAPL"),
+        _invalid_outcome("NASDAQ:FAKE"),
+        _valid_outcome("NASDAQ:MSFT"),
+    ]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=symbols,
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    assert summary.results[0].symbol == "NASDAQ:AAPL"
+    assert summary.results[1].symbol == "NASDAQ:FAKE"
+    assert summary.results[2].symbol == "NASDAQ:MSFT"
+    assert summary.results[1].success is False
+    assert summary.results[1].attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_preflight_total_count_unchanged() -> None:
+    """total_count reflects deduplicated input length, not post-preflight count."""
+    outcomes = [_invalid_outcome("NASDAQ:FAKE1"), _invalid_outcome("NASDAQ:FAKE2")]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV"),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:FAKE1", "NASDAQ:FAKE2"],
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    # Both symbols rejected at pre-flight — total_count is still 2, not 0
+    assert summary.total_count == 2
+
+
+@pytest.mark.asyncio
+async def test_preflight_dedup_and_order_with_mixed_results(mock_bars: list[OHLCVBar]) -> None:
+    """Duplicates removed first; then mixed invalid/valid results preserve deduped order."""
+    # Input has a duplicate of AAPL; after dedup: [AAPL, FAKE]
+    symbols = ["NASDAQ:AAPL", "nasdaq:aapl", "NASDAQ:FAKE"]
+    outcomes = [_valid_outcome("NASDAQ:AAPL"), _invalid_outcome("NASDAQ:FAKE")]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=symbols,
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+            )
+        )
+
+    assert summary.total_count == 2  # deduplicated
+    assert summary.results[0].symbol == "NASDAQ:AAPL"
+    assert summary.results[1].symbol == "NASDAQ:FAKE"
+    assert summary.results[0].success is True
+    assert summary.results[1].success is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_progress_total_uses_original_deduped_count(
+    mock_bars: list[OHLCVBar],
+) -> None:
+    """on_progress(..., total) stays aligned with original deduplicated input size."""
+    total_values: list[int] = []
+
+    def progress(result: object, completed: int, total: int) -> None:
+        total_values.append(total)
+
+    # One valid, one invalid — total after pre-flight would be 1, but total must stay 2
+    outcomes = [_valid_outcome("NASDAQ:AAPL"), _invalid_outcome("NASDAQ:FAKE")]
+
+    with (
+        patch(
+            "tvkit.batch.downloader.validate_symbol_detailed",
+            side_effect=outcomes,
+        ),
+        patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)),
+    ):
+        await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL", "NASDAQ:FAKE"],
+                interval="1D",
+                bars_count=1,
+                validate_symbols_before_fetch=True,
+                on_progress=progress,
+            )
+        )
+
+    # on_progress is only called for fetch tasks (not pre-flight rejections)
+    # AAPL proceeds to fetch → callback called once with total=2
+    assert total_values == [2]

--- a/tests/test_batch_downloader.py
+++ b/tests/test_batch_downloader.py
@@ -11,8 +11,18 @@ Covers:
 - Non-retryable NoHistoricalDataError (no retry)
 - on_progress callback behavior
 - BatchDownloadRequest mutual-exclusivity validation
+Phase 2 additions:
+- Full BatchDownloadRequest validation (interval, browser, concurrency, max_attempts,
+  date-range order, invalid ISO 8601, empty symbols)
+- auth_token SecretStr: repr() and log non-disclosure
+- ErrorInfo.exception_type and ErrorInfo.attempt correctness (non-retryable, exhaustion,
+  catch-all paths)
+- Structured logging LogRecord field assertions (WARNING per-attempt, WARNING non-retryable,
+  ERROR catch-all with exc_info, INFO batch-complete)
+- catch-all handler converts unexpected exception to SymbolResult failure
 """
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -380,3 +390,343 @@ async def test_on_progress_callback_exception_swallowed(mock_bars: list[OHLCVBar
     # Batch completes successfully despite the callback raising
     assert summary.success_count == 1
     assert summary.failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: BatchDownloadRequest validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_symbols_raises() -> None:
+    """Empty symbols list raises ValidationError (min_length=1 on symbols field)."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(symbols=[], interval="1D", bars_count=1)
+
+
+def test_invalid_interval_raises() -> None:
+    """Unrecognised interval string raises ValidationError."""
+    with pytest.raises(ValidationError, match="[Ii]nterval"):
+        BatchDownloadRequest(symbols=["NASDAQ:AAPL"], interval="INVALID", bars_count=1)
+
+
+def test_invalid_browser_raises() -> None:
+    """Unsupported browser string raises ValidationError."""
+    with pytest.raises(ValidationError, match="[Bb]rowser"):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            bars_count=1,
+            browser="safari",
+        )
+
+
+def test_invalid_concurrency_zero_raises() -> None:
+    """concurrency=0 raises ValidationError (ge=1)."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            bars_count=1,
+            concurrency=0,
+        )
+
+
+def test_invalid_max_attempts_zero_raises() -> None:
+    """max_attempts=0 raises ValidationError (ge=1)."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            bars_count=1,
+            max_attempts=0,
+        )
+
+
+def test_end_before_start_raises() -> None:
+    """end <= start raises ValidationError from validate_fetch_mode."""
+    with pytest.raises(ValidationError, match="[Ee]nd"):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            start="2024-06-01",
+            end="2024-01-01",
+        )
+
+
+def test_invalid_iso_datetime_raises() -> None:
+    """Unparseable start string raises ValidationError."""
+    with pytest.raises(ValidationError):
+        BatchDownloadRequest(
+            symbols=["NASDAQ:AAPL"],
+            interval="1D",
+            start="not-a-date",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: auth_token SecretStr non-disclosure
+# ---------------------------------------------------------------------------
+
+
+def test_auth_token_secret_str_repr() -> None:
+    """repr() of a BatchDownloadRequest never exposes the raw auth_token value."""
+    secret = "super_secret_token_12345"
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        bars_count=1,
+        auth_token=secret,
+    )
+    assert secret not in repr(request)
+
+
+@pytest.mark.asyncio
+async def test_auth_token_not_in_logs(
+    mock_bars: list[OHLCVBar],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The raw auth_token value never appears in any log record after a batch run."""
+    secret = "super_secret_token_67890"
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL"],
+        interval="1D",
+        bars_count=1,
+        auth_token=secret,
+    )
+    with caplog.at_level(logging.DEBUG, logger="tvkit.batch.downloader"):
+        with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+            await batch_download(request)
+
+    all_log_text = " ".join(r.getMessage() for r in caplog.records)
+    assert secret not in all_log_text
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: ErrorInfo correctness (exception_type + attempt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_info_on_non_retryable_exception_type() -> None:
+    """Non-retryable ValueError: error.exception_type contains 'ValueError', attempt==1."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(ValueError("bad input")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=3,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.error is not None
+    assert "ValueError" in result.error.exception_type
+    assert result.error.attempt == 1  # no retries
+
+
+@pytest.mark.asyncio
+async def test_error_info_on_retry_exhaustion_exception_type() -> None:
+    """Retry exhaustion: error.exception_type contains 'StreamConnectionError', attempt==max_attempts."""
+    max_attempts = 3
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(StreamConnectionError("dropped")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=max_attempts,
+                base_backoff=0.0001,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.error is not None
+    assert "StreamConnectionError" in result.error.exception_type
+    assert result.error.attempt == max_attempts
+
+
+@pytest.mark.asyncio
+async def test_error_info_on_catch_all_exception_type() -> None:
+    """Unexpected KeyError: caught by broad handler → error.exception_type contains 'KeyError'."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(KeyError("unexpected")),
+    ):
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=2,
+            )
+        )
+
+    result = summary.results[0]
+    assert result.success is False
+    assert result.error is not None
+    assert "KeyError" in result.error.exception_type
+    assert result.error.attempt >= 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Structured logging — LogRecord field assertions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retryable_warning_log_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """WARNING log on retryable failure includes symbol, attempt, max_attempts, exception_type."""
+    with caplog.at_level(logging.WARNING, logger="tvkit.batch.downloader"):
+        with patch(
+            "tvkit.batch.downloader.OHLCV",
+            return_value=_make_failing_client(StreamConnectionError("dropped")),
+        ):
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL"],
+                    interval="1D",
+                    bars_count=1,
+                    max_attempts=2,
+                    base_backoff=0.0001,
+                )
+            )
+
+    # Find a WARNING record from the retryable path
+    retry_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "will retry" in r.getMessage()
+    ]
+    assert retry_records, "Expected at least one WARNING with 'will retry'"
+    rec = retry_records[0]
+    assert rec.symbol == "NASDAQ:AAPL"  # type: ignore[attr-defined]
+    assert rec.attempt == 1  # type: ignore[attr-defined]
+    assert rec.max_attempts == 2  # type: ignore[attr-defined]
+    assert "StreamConnectionError" in rec.exception_type  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_warning_log_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """WARNING log on non-retryable failure includes symbol, attempt, exception_type."""
+    with caplog.at_level(logging.WARNING, logger="tvkit.batch.downloader"):
+        with patch(
+            "tvkit.batch.downloader.OHLCV",
+            return_value=_make_failing_client(ValueError("bad")),
+        ):
+            await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL"],
+                    interval="1D",
+                    bars_count=1,
+                    max_attempts=3,
+                )
+            )
+
+    non_retryable_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "non-retryable" in r.getMessage()
+    ]
+    assert non_retryable_records, "Expected at least one WARNING with 'non-retryable'"
+    rec = non_retryable_records[0]
+    assert rec.symbol == "NASDAQ:AAPL"  # type: ignore[attr-defined]
+    assert rec.attempt == 1  # type: ignore[attr-defined]
+    assert "ValueError" in rec.exception_type  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_error_log(caplog: pytest.LogCaptureFixture) -> None:
+    """Unexpected exception is logged at ERROR level with exc_info and correct fields."""
+    with caplog.at_level(logging.ERROR, logger="tvkit.batch.downloader"):
+        with patch(
+            "tvkit.batch.downloader.OHLCV",
+            return_value=_make_failing_client(KeyError("unexpected")),
+        ):
+            summary = await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL"],
+                    interval="1D",
+                    bars_count=1,
+                    max_attempts=1,
+                )
+            )
+
+    # Batch still returns a summary — exception was absorbed
+    assert summary.failure_count == 1
+
+    error_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR and "unexpected" in r.getMessage().lower()
+    ]
+    assert error_records, "Expected at least one ERROR log for unexpected exception"
+    rec = error_records[0]
+    assert rec.exc_info is not None  # exc_info=True was passed
+    assert rec.symbol == "NASDAQ:AAPL"  # type: ignore[attr-defined]
+    assert "KeyError" in rec.exception_type  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_batch_complete_info_log_fields(
+    mock_bars: list[OHLCVBar],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """INFO 'Batch download complete' log includes total, success, failure, elapsed fields."""
+    with caplog.at_level(logging.INFO, logger="tvkit.batch.downloader"):
+        with patch("tvkit.batch.downloader.OHLCV", return_value=_make_mock_client(mock_bars)):
+            summary = await batch_download(
+                BatchDownloadRequest(
+                    symbols=["NASDAQ:AAPL", "NASDAQ:MSFT"],
+                    interval="1D",
+                    bars_count=1,
+                )
+            )
+
+    complete_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "complete" in r.getMessage().lower()
+    ]
+    assert complete_records, "Expected at least one INFO log with 'complete'"
+    rec = complete_records[0]
+    assert rec.total == summary.total_count  # type: ignore[attr-defined]
+    assert rec.success == summary.success_count  # type: ignore[attr-defined]
+    assert rec.failure == summary.failure_count  # type: ignore[attr-defined]
+    assert rec.elapsed >= 0.0  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: catch-all handler converts unexpected exception to failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_converted_to_failure() -> None:
+    """KeyError from inside OHLCV is caught by the broad handler → SymbolResult failure."""
+    with patch(
+        "tvkit.batch.downloader.OHLCV",
+        return_value=_make_failing_client(KeyError("internal oops")),
+    ):
+        # batch_download must NOT raise — the exception is absorbed
+        summary = await batch_download(
+            BatchDownloadRequest(
+                symbols=["NASDAQ:AAPL"],
+                interval="1D",
+                bars_count=1,
+                max_attempts=1,
+            )
+        )
+
+    assert summary.failure_count == 1
+    assert summary.success_count == 0
+    result = summary.results[0]
+    assert result.success is False
+    assert result.bars == []
+    assert result.error is not None

--- a/tvkit/api/utils/__init__.py
+++ b/tvkit/api/utils/__init__.py
@@ -30,7 +30,12 @@ from .models import (
     SymbolConversionResult,
 )
 from .retry import calculate_backoff_delay
-from .symbol_validator import convert_symbol_format, validate_symbols
+from .symbol_validator import (
+    SymbolValidationOutcome,
+    convert_symbol_format,
+    validate_symbol_detailed,
+    validate_symbols,
+)
 from .timestamp import convert_timestamp_to_iso
 
 __all__ = [
@@ -38,7 +43,9 @@ __all__ = [
     "calculate_backoff_delay",
     "convert_timestamp_to_iso",
     "validate_symbols",
+    "validate_symbol_detailed",
     "convert_symbol_format",
+    "SymbolValidationOutcome",
     "fetch_tradingview_indicators",
     "display_and_select_indicator",
     "fetch_indicator_metadata",

--- a/tvkit/api/utils/symbol_validator.py
+++ b/tvkit/api/utils/symbol_validator.py
@@ -10,8 +10,36 @@ import logging
 import warnings
 
 import httpx
+from pydantic import BaseModel, Field
 
 from .models import SymbolConversionResult
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class SymbolValidationOutcome(BaseModel):
+    """Structured result of a single-symbol validation check.
+
+    Three possible outcomes:
+    - ``is_valid=True``: TradingView confirmed the symbol exists (HTTP 200/301).
+    - ``is_known_invalid=True``: TradingView explicitly rejected the symbol (HTTP 404).
+    - Both ``False``: validation could not determine status (transport/server failure).
+
+    Callers should treat the third case as fail-open — proceed to fetch rather than
+    reject, because the uncertainty is due to infrastructure, not the symbol itself.
+    """
+
+    symbol: str = Field(description="Canonical symbol that was validated")
+    is_valid: bool = Field(
+        description="True only when TradingView confirms the symbol is valid (HTTP 200/301)"
+    )
+    is_known_invalid: bool = Field(
+        description="True only when TradingView explicitly rejects the symbol (HTTP 404)"
+    )
+    message: str | None = Field(
+        default=None,
+        description="Optional reason for invalid or indeterminate validation outcome",
+    )
 
 
 async def validate_symbols(exchange_symbol: str | list[str]) -> bool:
@@ -104,6 +132,96 @@ async def validate_symbols(exchange_symbol: str | list[str]) -> bool:
                         ) from exc
 
     return True
+
+
+async def validate_symbol_detailed(symbol: str) -> SymbolValidationOutcome:
+    """Validate a single symbol and return a structured outcome.
+
+    Makes up to 3 HTTP attempts against TradingView's symbol URL. Unlike
+    ``validate_symbols()``, this function never raises — transport and server
+    failures are returned as an indeterminate outcome so the caller can
+    distinguish explicit invalidity from transient unavailability.
+
+    Outcome semantics:
+
+    - HTTP 200 or 301  → ``is_valid=True``, ``is_known_invalid=False``
+    - HTTP 404         → ``is_valid=False``, ``is_known_invalid=True``
+    - Any other error  → ``is_valid=False``, ``is_known_invalid=False``
+
+    Args:
+        symbol: TradingView symbol to validate (e.g. ``"NASDAQ:AAPL"``).
+
+    Returns:
+        SymbolValidationOutcome describing whether the symbol is valid, explicitly
+        invalid, or indeterminate.
+    """
+    validate_url: str = "https://www.tradingview.com/symbols/{exchange_symbol}"
+    retries: int = 3
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        for attempt in range(retries):
+            try:
+                response: httpx.Response = await client.get(
+                    url=validate_url.format(exchange_symbol=symbol)
+                )
+                if response.status_code in (200, 301):
+                    return SymbolValidationOutcome(
+                        symbol=symbol,
+                        is_valid=True,
+                        is_known_invalid=False,
+                    )
+                if response.status_code == 404:
+                    return SymbolValidationOutcome(
+                        symbol=symbol,
+                        is_valid=False,
+                        is_known_invalid=True,
+                        message=f"Symbol '{symbol}' not found (HTTP 404)",
+                    )
+                # Other HTTP error — treat as transient
+                logger.warning(
+                    "Unexpected HTTP status validating symbol",
+                    extra={
+                        "symbol": symbol,
+                        "attempt": attempt + 1,
+                        "status_code": response.status_code,
+                    },
+                )
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    return SymbolValidationOutcome(
+                        symbol=symbol,
+                        is_valid=False,
+                        is_known_invalid=True,
+                        message=f"Symbol '{symbol}' not found (HTTP 404)",
+                    )
+                logger.warning(
+                    "HTTP error validating symbol",
+                    extra={
+                        "symbol": symbol,
+                        "attempt": attempt + 1,
+                        "error": str(exc),
+                    },
+                )
+            except httpx.RequestError as exc:
+                logger.warning(
+                    "Transport error validating symbol",
+                    extra={
+                        "symbol": symbol,
+                        "attempt": attempt + 1,
+                        "error": str(exc),
+                    },
+                )
+
+            if attempt < retries - 1:
+                await asyncio.sleep(1.0)
+
+    # All attempts exhausted without an explicit valid/invalid response
+    return SymbolValidationOutcome(
+        symbol=symbol,
+        is_valid=False,
+        is_known_invalid=False,
+        message=f"Validation unavailable for '{symbol}' after {retries} attempts",
+    )
 
 
 def convert_symbol_format(

--- a/tvkit/batch/__init__.py
+++ b/tvkit/batch/__init__.py
@@ -1,0 +1,45 @@
+"""tvkit.batch — High-throughput async batch downloader for historical OHLCV data.
+
+Provides ``batch_download()``: an async function that fetches historical OHLCV bars
+for large symbol sets concurrently, with bounded concurrency, per-symbol retry with
+exponential backoff, and a structured ``BatchDownloadSummary`` separating successes
+from failures.
+
+Example::
+
+    from tvkit.batch import batch_download, BatchDownloadRequest
+
+    request = BatchDownloadRequest(
+        symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
+        interval="1D",
+        bars_count=252,
+        concurrency=5,
+    )
+    summary = await batch_download(request)
+
+    for result in summary.results:
+        if result.success:
+            print(f"{result.symbol}: {len(result.bars)} bars")
+        else:
+            print(f"{result.symbol}: FAILED — {result.error.message}")
+
+    print(f"Success: {summary.success_count}/{summary.total_count}")
+"""
+
+from tvkit.batch.downloader import batch_download
+from tvkit.batch.exceptions import BatchDownloadError
+from tvkit.batch.models import (
+    BatchDownloadRequest,
+    BatchDownloadSummary,
+    ErrorInfo,
+    SymbolResult,
+)
+
+__all__ = [
+    "BatchDownloadError",
+    "BatchDownloadRequest",
+    "BatchDownloadSummary",
+    "ErrorInfo",
+    "SymbolResult",
+    "batch_download",
+]

--- a/tvkit/batch/downloader.py
+++ b/tvkit/batch/downloader.py
@@ -1,0 +1,270 @@
+"""Core batch download implementation for tvkit.batch."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import websockets.exceptions
+
+from tvkit.api.chart.exceptions import NoHistoricalDataError, StreamConnectionError
+from tvkit.api.chart.ohlcv import OHLCV
+from tvkit.batch.exceptions import BatchDownloadError
+from tvkit.batch.models import (
+    BatchDownloadRequest,
+    BatchDownloadSummary,
+    ErrorInfo,
+    SymbolResult,
+)
+from tvkit.symbols import normalize_symbols
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Exceptions that indicate a transient failure — safe to retry.
+# Intentionally narrow — only exceptions with a clear transient signal:
+#   StreamConnectionError:            WebSocket dropped; retrying opens a fresh connection
+#   websockets.exceptions.*:          Underlying protocol error — typically transient
+#   TimeoutError (asyncio):           Request timed out — may succeed on next attempt
+#
+# Intentionally excluded:
+#   RuntimeError:                     Too broad; non-transient OHLCV logic failures would
+#                                     be silently retried and downgraded to failures
+#   ValueError:                       Programmer error / bad input — retrying cannot fix it
+#   NoHistoricalDataError(RuntimeError): TradingView confirms data absence — permanent
+_RETRYABLE: tuple[type[BaseException], ...] = (
+    StreamConnectionError,
+    websockets.exceptions.WebSocketException,
+    TimeoutError,
+)
+
+
+async def _fetch_one(
+    symbol: str,
+    semaphore: asyncio.Semaphore,
+    request: BatchDownloadRequest,
+) -> SymbolResult:
+    """Fetch historical OHLCV bars for a single symbol with per-attempt semaphore and retry.
+
+    The semaphore is acquired inside the retry loop (per attempt), not around the loop.
+    This ensures backoff sleep never occupies a concurrency slot — other symbols can
+    start their attempts while this one sleeps between retries.
+
+    Any exception not matched by the retryable or non-retryable clauses is caught by the
+    final broad handler, which converts it into a failed SymbolResult. This prevents
+    unexpected exceptions from escaping and aborting sibling tasks in asyncio.gather().
+
+    Args:
+        symbol: Canonical symbol in EXCHANGE:SYMBOL format.
+        semaphore: Shared asyncio.Semaphore capping in-flight connections.
+        request: Validated BatchDownloadRequest with retry and auth config.
+
+    Returns:
+        SymbolResult with success=True on any successful attempt, or
+        success=False after all attempts are exhausted or a non-retryable exception occurs.
+        Never raises — unexpected exceptions are converted to failed SymbolResult entries.
+    """
+    t0 = time.monotonic()
+    last_error: ErrorInfo | None = None
+    auth_token = request.auth_token.get_secret_value() if request.auth_token else None
+    attempt = 1  # initialised here so it is in scope after the loop
+
+    for attempt in range(1, request.max_attempts + 1):
+        try:
+            async with semaphore:  # slot acquired per attempt, not per retry loop
+                async with OHLCV(auth_token=auth_token, browser=request.browser) as client:
+                    if request.bars_count is not None:
+                        bars = await client.get_historical_ohlcv(
+                            exchange_symbol=symbol,
+                            interval=request.interval,
+                            bars_count=request.bars_count,
+                        )
+                    else:
+                        bars = await client.get_historical_ohlcv(
+                            exchange_symbol=symbol,
+                            interval=request.interval,
+                            start=request.start,
+                            end=request.end,
+                        )
+            # Slot released; success path
+            return SymbolResult(
+                symbol=symbol,
+                bars=bars,
+                success=True,
+                error=None,
+                attempts=attempt,
+                elapsed_seconds=time.monotonic() - t0,
+            )
+
+        except (ValueError, NoHistoricalDataError) as exc:
+            # Non-retryable: bad input or confirmed data absence.
+            # Catch before _RETRYABLE because NoHistoricalDataError is a RuntimeError subclass
+            # and could be matched by broad RuntimeError catches if present.
+            last_error = ErrorInfo(
+                message=str(exc),
+                exception_type=type(exc).__qualname__,
+                attempt=attempt,
+            )
+            logger.warning(
+                "Symbol fetch failed (non-retryable)",
+                extra={
+                    "symbol": symbol,
+                    "attempt": attempt,
+                    "exception_type": last_error.exception_type,
+                    "error": last_error.message,
+                },
+            )
+            break  # no retry
+
+        except _RETRYABLE as exc:
+            last_error = ErrorInfo(
+                message=str(exc),
+                exception_type=type(exc).__qualname__,
+                attempt=attempt,
+            )
+            logger.warning(
+                "Symbol fetch attempt failed — will retry",
+                extra={
+                    "symbol": symbol,
+                    "attempt": attempt,
+                    "max_attempts": request.max_attempts,
+                    "exception_type": last_error.exception_type,
+                    "error": last_error.message,
+                },
+            )
+            if attempt < request.max_attempts:
+                backoff = min(
+                    request.base_backoff * (2 ** (attempt - 1)),
+                    request.max_backoff,
+                )
+                await asyncio.sleep(backoff)  # semaphore released during sleep
+
+        except Exception as exc:  # noqa: BLE001
+            # Catch-all: unexpected exceptions (internal bugs, unhandled OHLCV conditions).
+            # Converted to a failed SymbolResult rather than propagating — prevents one
+            # symbol's unexpected failure from cancelling sibling tasks in gather().
+            last_error = ErrorInfo(
+                message=str(exc),
+                exception_type=type(exc).__qualname__,
+                attempt=attempt,
+            )
+            logger.error(
+                "Symbol fetch failed with unexpected exception",
+                extra={
+                    "symbol": symbol,
+                    "attempt": attempt,
+                    "exception_type": last_error.exception_type,
+                    "error": last_error.message,
+                },
+                exc_info=True,
+            )
+            break  # no retry for unexpected exceptions
+
+    # All attempts exhausted (or break from non-retryable / unexpected exception)
+    return SymbolResult(
+        symbol=symbol,
+        bars=[],
+        success=False,
+        error=last_error,
+        attempts=attempt,
+        elapsed_seconds=time.monotonic() - t0,
+    )
+
+
+async def batch_download(request: BatchDownloadRequest) -> BatchDownloadSummary:
+    """Download historical OHLCV bars for multiple symbols concurrently.
+
+    Symbols are normalized and deduplicated (order-preserving) before dispatch.
+    All symbols are started concurrently; the semaphore caps the number of
+    in-flight WebSocket connections at ``request.concurrency``.
+
+    Partial failures are collected in the returned ``BatchDownloadSummary``.
+    If ``request.strict=True``, ``BatchDownloadError`` is raised instead, but
+    the full summary (including successful results) is available on the exception.
+
+    Args:
+        request: Validated BatchDownloadRequest specifying symbols, interval,
+                 fetch mode (bars_count or date range), concurrency, and retry policy.
+
+    Returns:
+        BatchDownloadSummary with one SymbolResult per deduplicated input symbol,
+        in input order. Failed symbols are collected, not raised (unless strict=True).
+
+    Raises:
+        BatchDownloadError: If strict=True and one or more symbols fail.
+    """
+    # Normalize then deduplicate — order-preserving via dict.fromkeys
+    canonical: list[str] = list(dict.fromkeys(normalize_symbols(request.symbols)))
+    total = len(canonical)
+    semaphore = asyncio.Semaphore(request.concurrency)
+    t0_batch = time.monotonic()
+
+    # completed_count is safe without a lock: asyncio tasks run cooperatively on
+    # one event loop thread. There is no await between the read and write of
+    # completed_count inside _task(), so no other coroutine can interleave.
+    completed_count = 0
+
+    async def _task(symbol: str) -> SymbolResult:
+        nonlocal completed_count
+        result = await _fetch_one(symbol=symbol, semaphore=semaphore, request=request)
+        completed_count += 1
+        if request.on_progress is not None:
+            try:
+                request.on_progress(result, completed_count, total)
+            except Exception as cb_exc:  # noqa: BLE001
+                # Callback failure is logged and swallowed — a bad callback must not
+                # abort the batch or cancel successfully-downloaded symbols.
+                logger.error(
+                    "on_progress callback raised an exception",
+                    extra={
+                        "symbol": symbol,
+                        "completed": completed_count,
+                        "total": total,
+                        "error": str(cb_exc),
+                        "exception_type": type(cb_exc).__qualname__,
+                    },
+                    exc_info=True,
+                )
+        log_level = logging.INFO if result.success else logging.WARNING
+        logger.log(
+            log_level,
+            "Symbol batch result",
+            extra={
+                "symbol": symbol,
+                "success": result.success,
+                "bars": len(result.bars),
+                "attempts": result.attempts,
+                "elapsed": result.elapsed_seconds,
+            },
+        )
+        return result
+
+    results: list[SymbolResult] = list(await asyncio.gather(*(_task(s) for s in canonical)))
+
+    success_count = sum(1 for r in results if r.success)
+    summary = BatchDownloadSummary(
+        results=results,
+        total_count=total,
+        success_count=success_count,
+        failure_count=total - success_count,
+        elapsed_seconds=time.monotonic() - t0_batch,
+        interval=request.interval,
+    )
+
+    logger.info(
+        "Batch download complete",
+        extra={
+            "total": total,
+            "success": success_count,
+            "failure": total - success_count,
+            "elapsed": summary.elapsed_seconds,
+        },
+    )
+
+    if request.strict and summary.failure_count > 0:
+        raise BatchDownloadError(
+            f"{summary.failure_count} of {total} symbols failed",
+            summary=summary,
+        )
+
+    return summary

--- a/tvkit/batch/downloader.py
+++ b/tvkit/batch/downloader.py
@@ -10,6 +10,7 @@ import websockets.exceptions
 
 from tvkit.api.chart.exceptions import NoHistoricalDataError, StreamConnectionError
 from tvkit.api.chart.ohlcv import OHLCV
+from tvkit.api.utils.symbol_validator import validate_symbol_detailed
 from tvkit.batch.exceptions import BatchDownloadError
 from tvkit.batch.models import (
     BatchDownloadRequest,
@@ -20,6 +21,10 @@ from tvkit.batch.models import (
 from tvkit.symbols import normalize_symbols
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Pre-flight validation constants
+PRE_FLIGHT_WARNING_THRESHOLD: int = 200
+SYMBOL_VALIDATION_ERROR_TYPE: str = "SymbolValidationError"
 
 # Exceptions that indicate a transient failure — safe to retry.
 # Intentionally narrow — only exceptions with a clear transient signal:
@@ -37,6 +42,79 @@ _RETRYABLE: tuple[type[BaseException], ...] = (
     websockets.exceptions.WebSocketException,
     TimeoutError,
 )
+
+
+async def _preflight_validate(
+    symbols: list[str],
+) -> tuple[list[str], list[SymbolResult]]:
+    """Pre-validate symbols via TradingView HTTP API before the concurrent fetch phase.
+
+    Symbols confirmed invalid (HTTP 404) are rejected immediately as
+    ``SymbolResult(success=False, attempts=0, error=ErrorInfo(attempt=0))``.
+    Symbols that pass or whose validation is indeterminate (transport/server failure)
+    proceed to ``_fetch_one()`` unchanged — validation fails open to avoid dropping
+    symbols due to validator unavailability.
+
+    A WARNING is emitted if the batch exceeds ``PRE_FLIGHT_WARNING_THRESHOLD`` symbols,
+    because validation is serial and adds one HTTP call per symbol.
+
+    Args:
+        symbols: Deduplicated canonical symbols to validate (order-preserving).
+
+    Returns:
+        Tuple of:
+        - ``valid_symbols``: Symbols that passed or had indeterminate validation.
+        - ``prefailed``: ``SymbolResult`` entries for confirmed-invalid symbols.
+    """
+    if len(symbols) > PRE_FLIGHT_WARNING_THRESHOLD:
+        logger.warning(
+            "validate_symbols_before_fetch enabled for large batch — "
+            "this adds one HTTP call per symbol before any fetch begins",
+            extra={"symbol_count": len(symbols)},
+        )
+
+    valid: list[str] = []
+    prefailed: list[SymbolResult] = []
+
+    for symbol in symbols:
+        t0 = time.monotonic()
+        outcome = await validate_symbol_detailed(symbol)
+
+        if outcome.is_valid:
+            valid.append(symbol)
+            continue
+
+        if outcome.is_known_invalid:
+            logger.warning(
+                "Symbol failed pre-flight validation — skipping fetch",
+                extra={"symbol": symbol, "reason": outcome.message},
+            )
+            prefailed.append(
+                SymbolResult(
+                    symbol=symbol,
+                    bars=[],
+                    success=False,
+                    error=ErrorInfo(
+                        message=(
+                            outcome.message or f"Symbol '{symbol}' failed pre-flight validation"
+                        ),
+                        exception_type=SYMBOL_VALIDATION_ERROR_TYPE,
+                        attempt=0,
+                    ),
+                    attempts=0,
+                    elapsed_seconds=time.monotonic() - t0,
+                )
+            )
+            continue
+
+        # Indeterminate — transport or server failure; fail open
+        logger.warning(
+            "Pre-flight validation unavailable — allowing symbol to proceed to fetch",
+            extra={"symbol": symbol, "reason": outcome.message},
+        )
+        valid.append(symbol)
+
+    return valid, prefailed
 
 
 async def _fetch_one(
@@ -194,8 +272,16 @@ async def batch_download(request: BatchDownloadRequest) -> BatchDownloadSummary:
         BatchDownloadError: If strict=True and one or more symbols fail.
     """
     # Normalize then deduplicate — order-preserving via dict.fromkeys
-    canonical: list[str] = list(dict.fromkeys(normalize_symbols(request.symbols)))
-    total = len(canonical)
+    original_canonical: list[str] = list(dict.fromkeys(normalize_symbols(request.symbols)))
+    # total is based on deduplicated input *before* pre-flight filtering
+    total = len(original_canonical)
+
+    # Phase 4: opt-in pre-flight symbol validation
+    prefailed: list[SymbolResult] = []
+    canonical: list[str] = list(original_canonical)
+    if request.validate_symbols_before_fetch:
+        canonical, prefailed = await _preflight_validate(canonical)
+
     semaphore = asyncio.Semaphore(request.concurrency)
     t0_batch = time.monotonic()
 
@@ -239,7 +325,11 @@ async def batch_download(request: BatchDownloadRequest) -> BatchDownloadSummary:
         )
         return result
 
-    results: list[SymbolResult] = list(await asyncio.gather(*(_task(s) for s in canonical)))
+    fetch_results: list[SymbolResult] = list(await asyncio.gather(*(_task(s) for s in canonical)))
+
+    # Merge pre-flight failures with fetch results, preserving original input order
+    symbol_to_result: dict[str, SymbolResult] = {r.symbol: r for r in prefailed + fetch_results}
+    results: list[SymbolResult] = [symbol_to_result[s] for s in original_canonical]
 
     success_count = sum(1 for r in results if r.success)
     summary = BatchDownloadSummary(

--- a/tvkit/batch/exceptions.py
+++ b/tvkit/batch/exceptions.py
@@ -1,0 +1,40 @@
+"""Exception types for the tvkit.batch package."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tvkit.batch.models import BatchDownloadSummary
+
+__all__ = ["BatchDownloadError"]
+
+
+class BatchDownloadError(Exception):
+    """Raised by batch_download() when strict=True and one or more symbols fail.
+
+    Also raised by BatchDownloadSummary.raise_if_failed() after the fact.
+    The summary is always attached so callers can inspect partial results even
+    when this exception is raised.
+
+    Attributes:
+        summary: The full BatchDownloadSummary, including successful results.
+
+    Example:
+        >>> try:
+        ...     summary = await batch_download(request)
+        ... except BatchDownloadError as exc:
+        ...     print(f"Failed symbols: {exc.failed_symbols}")
+        ...     for result in exc.summary.results:
+        ...         if result.success:
+        ...             process(result)
+    """
+
+    def __init__(self, message: str, summary: BatchDownloadSummary) -> None:
+        super().__init__(message)
+        self.summary: BatchDownloadSummary = summary
+
+    @property
+    def failed_symbols(self) -> list[str]:
+        """Canonical symbols that failed after all retry attempts."""
+        return self.summary.failed_symbols

--- a/tvkit/batch/models.py
+++ b/tvkit/batch/models.py
@@ -244,7 +244,7 @@ class BatchDownloadRequest(BaseModel):
             "Signature: (result: SymbolResult, completed: int, total: int) -> None. "
             "Called after both successes and failures. completed is 1-based. "
             "Async callables are rejected — this callback must be synchronous. "
-            "Exceptions raised by the callback propagate immediately out of batch_download()."
+            "Exceptions raised by the callback are logged and swallowed — a bad callback does not abort the batch."
         ),
         exclude=True,  # not JSON-serializable — excluded from model_dump()
     )

--- a/tvkit/batch/models.py
+++ b/tvkit/batch/models.py
@@ -344,7 +344,7 @@ class BatchDownloadRequest(BaseModel):
         if has_start and self.end is not None:
             # Both are UTC-aware at this point (normalized in field_validator).
             # has_start guarantees self.start is not None; checked explicitly for type safety.
-            if self.start is None:
+            if self.start is None:  # pragma: no cover
                 raise ValueError("Internal error: has_start is True but self.start is None")
             if self.end <= self.start:
                 raise ValueError(

--- a/tvkit/batch/models.py
+++ b/tvkit/batch/models.py
@@ -1,0 +1,331 @@
+"""Pydantic models for tvkit.batch batch download operations."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field, SecretStr, computed_field, field_validator, model_validator
+
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.api.chart.utils import validate_interval
+
+__all__ = [
+    "BatchDownloadRequest",
+    "BatchDownloadSummary",
+    "ErrorInfo",
+    "SymbolResult",
+]
+
+_VALID_BROWSERS: frozenset[str] = frozenset({"chrome", "firefox"})
+
+
+def _to_utc_aware(dt: datetime) -> datetime:
+    """Return a UTC-aware datetime. Naive datetimes are assumed to be UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+class ErrorInfo(BaseModel):
+    """Structured error record for a failed symbol fetch.
+
+    Populated on the attempt where the terminal error occurred — either the last
+    retryable attempt or the first non-retryable attempt.
+    """
+
+    message: str = Field(description="Human-readable error message")
+    exception_type: str = Field(description="Fully qualified exception class name")
+    attempt: int = Field(description="Attempt number on which this error occurred", ge=1)
+
+
+class SymbolResult(BaseModel):
+    """Result for a single symbol in a batch download.
+
+    Invariants enforced by model_validator:
+    - ``success=True``  → ``error is None``  and  ``bars`` may be non-empty
+    - ``success=False`` → ``error is not None`` and ``bars`` is empty
+
+    ``bars`` is always a list — never ``None``. Callers can iterate ``result.bars`` safely
+    without a None-check regardless of success status.
+    """
+
+    symbol: str = Field(description="Canonical symbol in EXCHANGE:SYMBOL format")
+    bars: list[OHLCVBar] = Field(
+        default_factory=list,
+        description="Fetched OHLCV bars, sorted chronologically (oldest first). Empty on failure.",
+    )
+    success: bool = Field(description="True if bars were fetched without error")
+    error: ErrorInfo | None = Field(
+        default=None,
+        description="Structured error detail if success is False, else None",
+    )
+    attempts: int = Field(
+        description="Number of fetch attempts made (1 = succeeded on first try)",
+        ge=1,
+    )
+    elapsed_seconds: float = Field(
+        description="Wall-clock seconds spent across all attempts for this symbol",
+        ge=0.0,
+    )
+
+    @model_validator(mode="after")
+    def validate_success_invariants(self) -> SymbolResult:
+        """Enforce consistency between success, error, and bars."""
+        if self.success:
+            if self.error is not None:
+                raise ValueError("success=True but error is set — these are mutually exclusive")
+        else:
+            if self.error is None:
+                raise ValueError("success=False requires error to be set")
+            if self.bars:
+                raise ValueError(
+                    "success=False but bars is non-empty — bars must be empty on failure"
+                )
+        return self
+
+
+class BatchDownloadSummary(BaseModel):
+    """Aggregated result of a batch_download() call.
+
+    ``results`` preserves the deduplicated input order — position i in ``results``
+    corresponds to position i in the deduplicated symbol list.
+
+    Counts (``total_count``, ``success_count``, ``failure_count``) are validated
+    to be consistent with ``results`` to prevent mismatches that would make
+    ``raise_if_failed()`` silently produce wrong behavior.
+    """
+
+    results: list[SymbolResult] = Field(
+        description="One SymbolResult per deduplicated input symbol, in input order"
+    )
+    total_count: int = Field(description="Number of symbols after deduplication", ge=0)
+    success_count: int = Field(description="Symbols fetched successfully", ge=0)
+    failure_count: int = Field(description="Symbols that failed after all retries", ge=0)
+    elapsed_seconds: float = Field(
+        description="Total wall-clock seconds for the entire batch",
+        ge=0.0,
+    )
+    interval: str = Field(description="Interval used for all fetches")
+
+    @model_validator(mode="after")
+    def validate_counts_consistent(self) -> BatchDownloadSummary:
+        """Enforce that counts are consistent with results."""
+        actual_total = len(self.results)
+        actual_success = sum(1 for r in self.results if r.success)
+        actual_failure = actual_total - actual_success
+
+        if self.total_count != actual_total:
+            raise ValueError(
+                f"total_count={self.total_count} does not match len(results)={actual_total}"
+            )
+        if self.success_count != actual_success:
+            raise ValueError(
+                f"success_count={self.success_count} does not match actual successes={actual_success}"
+            )
+        if self.failure_count != actual_failure:
+            raise ValueError(
+                f"failure_count={self.failure_count} does not match actual failures={actual_failure}"
+            )
+        return self
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def failed_symbols(self) -> list[str]:
+        """Canonical symbols that failed after all retry attempts."""
+        return [r.symbol for r in self.results if not r.success]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def successful_symbols(self) -> list[str]:
+        """Canonical symbols that were fetched successfully."""
+        return [r.symbol for r in self.results if r.success]
+
+    def raise_if_failed(self) -> None:
+        """Raise BatchDownloadError if any symbol failed.
+
+        Equivalent to having called batch_download() with strict=True, but
+        callable after the fact — useful for pipelines that want to inspect
+        the summary before deciding whether to treat failures as fatal.
+
+        Raises:
+            BatchDownloadError: If failure_count > 0.
+        """
+        if self.failure_count > 0:
+            from tvkit.batch.exceptions import BatchDownloadError
+
+            raise BatchDownloadError(
+                f"{self.failure_count} of {self.total_count} symbols failed",
+                summary=self,
+            )
+
+
+class BatchDownloadRequest(BaseModel):
+    """Validated input parameters for batch_download().
+
+    Exactly one fetch mode must be provided:
+    - ``bars_count``: fetch the N most recent bars per symbol
+    - ``start`` (with optional ``end``): fetch a date range per symbol
+
+    ``start`` and ``end`` accept ISO 8601 strings or ``datetime`` objects; strings are
+    parsed and naive datetimes normalized to UTC at construction time so downstream
+    date arithmetic is always timezone-safe.
+
+    ``auth_token`` is stored as SecretStr and never logged or repr'd in plain text.
+    ``on_progress`` is excluded from model serialization (not JSON-safe).
+    """
+
+    symbols: list[str] = Field(
+        min_length=1,
+        description=(
+            "List of TradingView symbols. Normalized and deduplicated before fetch. "
+            "At least one symbol required."
+        ),
+    )
+    interval: str = Field(
+        default="1D",
+        description="Timeframe interval. Valid values: '1', '5', '15', '30', '60', '1H', '4H', '1D', '1W', '1M'",
+    )
+    bars_count: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Number of historical bars to fetch per symbol (most recent N bars). "
+            "Mutually exclusive with start/end."
+        ),
+    )
+    start: datetime | None = Field(
+        default=None,
+        description=(
+            "Range start. Accepts ISO 8601 string or datetime — normalized to UTC. "
+            "Mutually exclusive with bars_count. end defaults to now if omitted."
+        ),
+    )
+    end: datetime | None = Field(
+        default=None,
+        description=(
+            "Range end. Accepts ISO 8601 string or datetime — normalized to UTC. "
+            "Defaults to current UTC time if start is set but end is omitted."
+        ),
+    )
+    concurrency: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum number of in-flight OHLCV connections at any moment.",
+    )
+    max_attempts: int = Field(
+        default=3,
+        ge=1,
+        description="Per-symbol retry limit (includes the initial attempt).",
+    )
+    base_backoff: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Initial backoff in seconds. Doubles each attempt up to max_backoff.",
+    )
+    max_backoff: float = Field(
+        default=30.0,
+        gt=0.0,
+        description="Maximum backoff ceiling in seconds.",
+    )
+    auth_token: SecretStr | None = Field(
+        default=None,
+        description="TradingView auth token. Stored as SecretStr — never logged. Equivalent to OHLCV(auth_token=...).",
+    )
+    browser: str | None = Field(
+        default=None,
+        description="Browser for cookie extraction. Accepted values: 'chrome', 'firefox'.",
+    )
+    on_progress: Callable[[SymbolResult, int, int], None] | None = Field(
+        default=None,
+        description=(
+            "Optional sync callback invoked after each symbol resolves. "
+            "Signature: (result: SymbolResult, completed: int, total: int) -> None. "
+            "Called after both successes and failures. completed is 1-based. "
+            "Async callables are rejected — this callback must be synchronous. "
+            "Exceptions raised by the callback propagate immediately out of batch_download()."
+        ),
+        exclude=True,  # not JSON-serializable — excluded from model_dump()
+    )
+    strict: bool = Field(
+        default=False,
+        description=(
+            "If True, raise BatchDownloadError when any symbol fails. "
+            "If False (default), failures are collected in BatchDownloadSummary."
+        ),
+    )
+
+    model_config = {"arbitrary_types_allowed": True}  # required for Callable field
+
+    @field_validator("start", "end", mode="before")
+    @classmethod
+    def parse_and_normalize_datetime(cls, value: str | datetime | None) -> datetime | None:
+        """Parse ISO 8601 strings and normalize all datetimes to UTC-aware."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            try:
+                value = datetime.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid datetime string: {value!r}. "
+                    "Expected ISO 8601 format, e.g. '2024-01-01' or '2024-01-01T00:00:00Z'."
+                ) from exc
+        return _to_utc_aware(value)
+
+    @field_validator("interval")
+    @classmethod
+    def validate_interval_value(cls, value: str) -> str:
+        """Validate against known TradingView interval formats."""
+        validate_interval(value)
+        return value
+
+    @field_validator("browser")
+    @classmethod
+    def validate_browser_value(cls, value: str | None) -> str | None:
+        """Validate browser is one of the supported values."""
+        if value is not None and value not in _VALID_BROWSERS:
+            raise ValueError(
+                f"Invalid browser: {value!r}. Must be one of: {sorted(_VALID_BROWSERS)}"
+            )
+        return value
+
+    @field_validator("on_progress", mode="before")
+    @classmethod
+    def reject_async_callback(
+        cls, value: Callable[[SymbolResult, int, int], None] | None
+    ) -> Callable[[SymbolResult, int, int], None] | None:
+        """Reject coroutine functions — on_progress must be synchronous."""
+        if value is not None and inspect.iscoroutinefunction(value):
+            raise ValueError(
+                "on_progress must be a synchronous callable. "
+                "Async callables are not supported — the callback is invoked without await."
+            )
+        return value
+
+    @model_validator(mode="after")
+    def validate_fetch_mode(self) -> BatchDownloadRequest:
+        """Enforce mutual exclusivity between bars_count and start/end, and range order."""
+        has_bars = self.bars_count is not None
+        has_start = self.start is not None
+        if has_bars and has_start:
+            raise ValueError(
+                "Provide bars_count or start/end, not both. "
+                "bars_count fetches the N most recent bars; start/end fetches a date range."
+            )
+        if not has_bars and not has_start:
+            raise ValueError(
+                "Either bars_count or start must be provided. "
+                "Use bars_count for the N most recent bars, or start (with optional end) for a date range."
+            )
+        if has_start and self.end is not None:
+            # Both are UTC-aware at this point (normalized in field_validator).
+            # has_start guarantees self.start is not None; checked explicitly for type safety.
+            if self.start is None:
+                raise ValueError("Internal error: has_start is True but self.start is None")
+            if self.end <= self.start:
+                raise ValueError(
+                    f"end ({self.end.isoformat()}) must be after start ({self.start.isoformat()})."
+                )
+        return self

--- a/tvkit/batch/models.py
+++ b/tvkit/batch/models.py
@@ -37,7 +37,14 @@ class ErrorInfo(BaseModel):
 
     message: str = Field(description="Human-readable error message")
     exception_type: str = Field(description="Fully qualified exception class name")
-    attempt: int = Field(description="Attempt number on which this error occurred", ge=1)
+    attempt: int = Field(
+        description=(
+            "Attempt number on which this error occurred. "
+            "0 = rejected at pre-flight validation (never fetched). "
+            "1+ = fetch attempt number."
+        ),
+        ge=0,
+    )
 
 
 class SymbolResult(BaseModel):
@@ -62,8 +69,12 @@ class SymbolResult(BaseModel):
         description="Structured error detail if success is False, else None",
     )
     attempts: int = Field(
-        description="Number of fetch attempts made (1 = succeeded on first try)",
-        ge=1,
+        description=(
+            "Number of fetch attempts made. "
+            "0 = rejected at pre-flight (no fetch attempted). "
+            "1+ = number of fetch attempts made."
+        ),
+        ge=0,
     )
     elapsed_seconds: float = Field(
         description="Wall-clock seconds spent across all attempts for this symbol",
@@ -247,6 +258,17 @@ class BatchDownloadRequest(BaseModel):
             "Exceptions raised by the callback are logged and swallowed — a bad callback does not abort the batch."
         ),
         exclude=True,  # not JSON-serializable — excluded from model_dump()
+    )
+    validate_symbols_before_fetch: bool = Field(
+        default=False,
+        description=(
+            "Pre-validate all symbols via TradingView HTTP API before fetching. "
+            "Symbols confirmed invalid (HTTP 404) become SymbolResult(success=False, attempts=0) "
+            "immediately — no WebSocket connection is opened for them. "
+            "Validation failures due to transport or server errors fail open: the symbol "
+            "proceeds to _fetch_one() unchanged. "
+            "Not recommended for batches > 200 symbols — adds one HTTP call per symbol."
+        ),
     )
     strict: bool = Field(
         default=False,


### PR DESCRIPTION
## Summary

Adds `tvkit.batch` — a high-throughput async batch downloader for historical OHLCV data, shipped as v0.10.0.

**PyPI:** https://pypi.org/project/tvkit/0.10.0/

---

## What's New

### `tvkit.batch` module

New public module for fetching historical OHLCV data for large symbol sets concurrently:

```python
from tvkit.batch import batch_download, BatchDownloadRequest

request = BatchDownloadRequest(
    symbols=["NASDAQ:AAPL", "NASDAQ:MSFT", "NYSE:JPM"],
    interval="1D",
    bars_count=252,
    concurrency=5,
)
summary = await batch_download(request)

for result in summary.results:
    if result.success and result.bars:
        print(f"{result.symbol}: {len(result.bars)} bars")
```

### Key capabilities

| Capability | Details |
|---|---|
| Bounded concurrency | `asyncio.Semaphore` caps in-flight WebSocket connections |
| Per-symbol retry | Exponential backoff — `min(base * 2^(attempt-1), max)` |
| Partial failure | Failed symbols collected in `BatchDownloadSummary`; no exception by default |
| Strict mode | `strict=True` raises `BatchDownloadError` with partial successes in `exc.summary` |
| Progress callback | Sync `on_progress(result, completed, total)` called after each terminal result |
| Date-range mode | `start`/`end` in addition to `bars_count` |
| Deduplication | Normalized, order-preserving dedup before dispatch |
| Pre-flight validation | Optional `validate_symbols_before_fetch=True` via TradingView HTTP API |
| Auth support | `auth_token` (SecretStr) and `browser` cookie extraction |

### Public API

```python
from tvkit.batch import (
    batch_download,           # async def batch_download(request) -> BatchDownloadSummary
    BatchDownloadRequest,     # Pydantic input model
    BatchDownloadSummary,     # aggregated results
    SymbolResult,             # per-symbol result with bars, success, error, attempts
    ErrorInfo,                # structured error: message, exception_type, attempt
    BatchDownloadError,       # raised in strict mode; carries full summary
)
```

---

## Implementation Phases

| Phase | Description |
|---|---|
| Phase 1 | Core async batch downloader with concurrency, retry, deduplication |
| Phase 2 | Error handling, validation, structured logging |
| Phase 3 | Progress callbacks, `BatchDownloadSummary.raise_if_failed()` |
| Phase 4 | Pre-flight symbol validation (`validate_symbols_before_fetch`) |
| Phase 5 | Full test coverage matrix (978 tests passing) |
| Phase 6 | Documentation, CHANGELOG, version bump, PyPI release |

---

## Documentation

- **API Reference:** `docs/reference/batch/downloader.md`
- **Workflow Guide:** `docs/guides/batch-download.md`
- **Example Script:** `examples/batch_sp500_historical.py` (4 runnable demos)
- **Architecture:** `docs/architecture/system-overview.md` updated
- **Roadmap:** Feature moved from Planned → Recently Shipped (v0.10.0)

---

## Quality Gates

```
ruff check . && ruff format .    ✅ pass (97 files, no issues)
mypy tvkit/                      ✅ pass (64 source files, no issues)
pytest tests/ -v                 ✅ 978 passed, 2 skipped
```

---

## Checklist

- [x] All tests pass
- [x] Type checking clean (`mypy`)
- [x] Linting clean (`ruff`)
- [x] API reference complete (`docs/reference/batch/downloader.md`)
- [x] Workflow guide complete (`docs/guides/batch-download.md`)
- [x] Example script verified (`examples/batch_sp500_historical.py`)
- [x] Architecture doc updated
- [x] CHANGELOG updated (v0.10.0)
- [x] Version bumped (`0.9.0 → 0.10.0`)
- [x] Roadmap updated
- [x] Published to PyPI v0.10.0
