### PR TITLE
feat(chart): dividend-adjusted OHLCV via Adjustment enum (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] — Unreleased
+
+### Added
+
+- **`Adjustment` enum** (`tvkit.api.chart.Adjustment`) with two members:
+  - `Adjustment.SPLITS` — split-adjusted prices only (default; identical to all pre-v0.11.0 behaviour)
+  - `Adjustment.DIVIDENDS` — dividend-adjusted (total-return) prices; all prior bars are backward-adjusted for cash dividends, producing accurate total-return series for long-term backtesting of dividend-paying stocks
+- **`adjustment` keyword parameter on `get_historical_ohlcv()`** — defaults to `Adjustment.SPLITS`; a raw string `"splits"` or `"dividends"` is coerced automatically; an unknown string raises `ValueError` before any network I/O
+- **`backadjustment: "default"` added to the historical OHLCV `resolve_symbol` WebSocket payload** — matches TradingView browser behaviour confirmed by HAR capture; applies to `add_symbol_to_sessions()` (historical OHLCV path) only
+
+### Notes
+
+- Existing calls to `get_historical_ohlcv()` without `adjustment` produce the same data as v0.10.0 — fully backwards-compatible
+- `Adjustment.NONE` (raw unadjusted prices) is not yet supported — protocol value not confirmed; tracked for a future release
+- `add_multiple_symbols_to_sessions()` (quote-data path) and `get_ohlcv()` / `get_ohlcv_raw()` / `get_quote_data()` are unchanged in this release
+
+---
+
 ## [0.10.0] — 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.0] — Unreleased
+## [0.11.0] — 2026-04-24
 
 ### Added
 

--- a/docs/reference/chart/ohlcv.md
+++ b/docs/reference/chart/ohlcv.md
@@ -11,6 +11,7 @@ Async WebSocket client for streaming real-time and historical OHLCV data from Tr
 
 ```python
 from tvkit.api.chart.ohlcv import OHLCV
+from tvkit.api.chart import Adjustment          # price adjustment mode enum
 ```
 
 ---
@@ -169,6 +170,7 @@ async def get_historical_ohlcv(
     *,
     start: datetime | str | None = None,
     end: datetime | str | None = None,
+    adjustment: Adjustment = Adjustment.SPLITS,
 ) -> list[OHLCVBar]: ...
 ```
 
@@ -181,6 +183,7 @@ async def get_historical_ohlcv(
 | `bars_count` | `int \| None` | `None` | Count mode: number of most-recent bars to fetch. Mutually exclusive with `start`/`end`. Must be a positive integer. No implicit default — must be provided explicitly in count mode. |
 | `start` | `datetime \| str \| None` | `None` | Range mode: start of date window (inclusive). Keyword-only. Accepts timezone-aware datetime, naive datetime (assigned UTC), or ISO 8601 string. Must be used together with `end`. |
 | `end` | `datetime \| str \| None` | `None` | Range mode: end of date window (inclusive). Keyword-only. Same accepted types as `start`. Must be used together with `start`. |
+| `adjustment` | `Adjustment` | `Adjustment.SPLITS` | Price adjustment mode. Keyword-only. `Adjustment.SPLITS` (default) — split-adjusted only, identical to pre-v0.11.0 behaviour. `Adjustment.DIVIDENDS` — dividend-adjusted (total-return) prices; all prior bars are backward-adjusted for cash dividends. A raw string `"splits"` or `"dividends"` is accepted and coerced automatically. An unknown string raises `ValueError` before any network I/O. |
 
 #### Mode Selection
 
@@ -241,6 +244,7 @@ The segment size is snapshotted once at the start of each fetch so that a mid-fl
 | `ValueError` | Only one of `start`/`end` provided |
 | `ValueError` | `bars_count <= 0` |
 | `ValueError` | `start > end` |
+| `ValueError` | `adjustment` string is not a recognised value (raised before any network I/O) |
 | `ValueError` | Symbol format is invalid (from `validate_symbols`) |
 | `ValueError` | Interval format is invalid (from `validate_interval`) |
 | `ValueError` | TradingView returns a `series_error` (invalid symbol/interval for the requested timeframe) |
@@ -283,6 +287,52 @@ async with OHLCV() as client:
         start=datetime(2024, 1, 1, tzinfo=UTC),
         end=datetime(2024, 12, 31, tzinfo=UTC),
     )
+```
+
+**Dividend-adjusted prices (count mode):**
+
+```python
+from tvkit.api.chart import OHLCV, Adjustment
+
+async with OHLCV() as client:
+    # Default — split-adjusted only; identical to all pre-v0.11.0 calls
+    splits_bars = await client.get_historical_ohlcv(
+        "SET:ADVANC", "1D", bars_count=300,
+        adjustment=Adjustment.SPLITS,
+    )
+
+    # Dividend-adjusted total-return prices
+    div_bars = await client.get_historical_ohlcv(
+        "SET:ADVANC", "1D", bars_count=300,
+        adjustment=Adjustment.DIVIDENDS,
+    )
+
+# Closing prices differ: dividend-adjusted bars are backward-adjusted for cash payouts
+print(splits_bars[-1].close)   # e.g. 280.0
+print(div_bars[-1].close)      # e.g. 254.9  (lower — dividends deducted from history)
+```
+
+**Dividend-adjusted prices (range mode):**
+
+```python
+async with OHLCV() as client:
+    bars = await client.get_historical_ohlcv(
+        "SET:ADVANC", "1D",
+        start="2025-01-01", end="2025-12-31",
+        adjustment=Adjustment.DIVIDENDS,
+    )
+```
+
+**Raw string coercion (both forms are equivalent):**
+
+```python
+# Enum form — preferred, IDE-autocomplete-friendly
+bars = await client.get_historical_ohlcv("SET:ADVANC", "1D", bars_count=5,
+                                          adjustment=Adjustment.DIVIDENDS)
+
+# String form — accepted and coerced silently
+bars = await client.get_historical_ohlcv("SET:ADVANC", "1D", bars_count=5,
+                                          adjustment="dividends")  # type: ignore[arg-type]
 ```
 
 ---
@@ -506,6 +556,32 @@ df_utc = convert_to_exchange_timezone(df, "BINANCE") # UTC (crypto, 24/7)
 
 See [Concepts: Timezones](../../concepts/timezones.md) for the full explanation, and
 [tvkit.time Reference](../time/index.md) for the complete API.
+
+### `Adjustment`
+
+```python
+from tvkit.api.chart import Adjustment
+```
+
+`StrEnum` controlling the price adjustment mode applied to historical OHLCV bars. Maps directly to the `adjustment` field in TradingView's `resolve_symbol` WebSocket message.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `Adjustment.SPLITS` | `"splits"` | Split-adjusted prices only. **Default.** Identical to all pre-v0.11.0 behaviour. |
+| `Adjustment.DIVIDENDS` | `"dividends"` | Dividend-adjusted (total-return) prices. Every prior bar is backward-adjusted so that each cash dividend payment is deducted from all earlier closing prices. Use for long-term backtesting of dividend-paying stocks. |
+
+Because `Adjustment` is a `str` enum, members compare equal to their string values:
+
+```python
+assert Adjustment.SPLITS == "splits"
+assert Adjustment.DIVIDENDS == "dividends"
+```
+
+`get_historical_ohlcv()` also accepts raw strings and coerces them automatically — a string that does not match a known member raises `ValueError` before any network I/O.
+
+**Added in v0.11.0.** `Adjustment.NONE` (raw unadjusted prices) is not yet supported — protocol value not confirmed; tracked for a future release.
+
+---
 
 ### `QuoteSymbolData`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,24 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 
 ## In Progress
 
+### Dividend-Adjusted OHLCV Data ([#30](https://github.com/lumduan/tvkit/issues/30))
+
+Add an `adjustment` parameter to `get_historical_ohlcv()` so callers can request dividend-adjusted prices in addition to the existing split-adjusted default.
+
+TradingView's WebSocket protocol exposes an `adjustment` field on `resolve_symbol` that tvkit currently hardcodes to `"splits"`. Exposing this as a first-class API option enables total-return backtesting and income analysis without requiring users to source and apply dividend data separately.
+
+```python
+from tvkit.api.chart import OHLCV, Adjustment
+
+async with OHLCV() as client:
+    bars = await client.get_historical_ohlcv(
+        "SET:ADVANC", "1D", bars_count=100,
+        adjustment=Adjustment.DIVIDENDS,
+    )
+```
+
+Phase 1 supports: `Adjustment.SPLITS` (default, backwards-compatible) and `Adjustment.DIVIDENDS`. `Adjustment.NONE` (raw unadjusted prices) is deferred — the exact protocol value was not observed in the HAR capture and requires a separate investigation.
+
 ---
 
 ## Planned

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 
 ## Recently Shipped
 
+- **v0.11.0** — Dividend-Adjusted OHLCV (`Adjustment` enum with `SPLITS` / `DIVIDENDS`; `adjustment` keyword parameter on `get_historical_ohlcv()`; `backadjustment: "default"` added to historical OHLCV WebSocket payload — protocol correctness fix)
 - **v0.10.0** — Async Batch Downloader (`tvkit.batch`: `batch_download()`, bounded concurrency via semaphore, per-symbol retry with exponential backoff, `BatchDownloadSummary`, partial failure model, opt-in pre-flight symbol validation)
 - **v0.9.0** — Data Integrity Validation (`tvkit.validation`: duplicate/monotonic/OHLC/volume/gap checks; `DataExporter` integration with `validate`, `strict`, `interval` parameters)
 - **v0.8.0** —  Symbol Normalization 
@@ -20,28 +21,6 @@ tvkit is evolving toward a **high-performance data infrastructure library for Tr
 - **v0.1.5** — Symbol format auto-conversion (dash → colon notation)
 - **v0.1.4** — Multi-market scanner with 69 markets and 101+ columns
 - **v0.1.0** — Initial release: real-time OHLCV streaming and historical data
-
----
-
-## In Progress
-
-### Dividend-Adjusted OHLCV Data ([#30](https://github.com/lumduan/tvkit/issues/30))
-
-Add an `adjustment` parameter to `get_historical_ohlcv()` so callers can request dividend-adjusted prices in addition to the existing split-adjusted default.
-
-TradingView's WebSocket protocol exposes an `adjustment` field on `resolve_symbol` that tvkit currently hardcodes to `"splits"`. Exposing this as a first-class API option enables total-return backtesting and income analysis without requiring users to source and apply dividend data separately.
-
-```python
-from tvkit.api.chart import OHLCV, Adjustment
-
-async with OHLCV() as client:
-    bars = await client.get_historical_ohlcv(
-        "SET:ADVANC", "1D", bars_count=100,
-        adjustment=Adjustment.DIVIDENDS,
-    )
-```
-
-Phase 1 supports: `Adjustment.SPLITS` (default, backwards-compatible) and `Adjustment.DIVIDENDS`. `Adjustment.NONE` (raw unadjusted prices) is deferred — the exact protocol value was not observed in the HAR capture and requires a separate investigation.
 
 ---
 

--- a/examples/ohlcv_dividend_adjusted.py
+++ b/examples/ohlcv_dividend_adjusted.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Dividend-Adjusted OHLCV — tvkit Example
+========================================
+
+Demonstrates how to request dividend-adjusted (total-return) prices using the
+``Adjustment`` enum, and compares them side-by-side with the default split-adjusted
+prices.
+
+Modes:
+- Interactive menu: choose symbol, interval, and fetch mode
+- Default demo: runs a preset comparison for SET:ADVANC
+
+Run:
+    uv run python examples/ohlcv_dividend_adjusted.py
+"""
+
+import asyncio
+import logging
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import IntPrompt, Prompt
+from rich.table import Table
+from rich.text import Text
+
+from tvkit.api.chart import OHLCV, Adjustment
+from tvkit.api.chart.exceptions import NoHistoricalDataError
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.api.utils import convert_timestamp_to_iso
+
+console: Console = Console()
+
+# Suppress tvkit internal logs so rich output stays clean in this demo.
+logging.getLogger("tvkit").setLevel(logging.CRITICAL)
+
+# Default symbol for the preset demo
+DEFAULT_SYMBOL: str = "SET:ADVANC"
+DEFAULT_INTERVAL: str = "1D"
+DEFAULT_COUNT_BARS: int = 300
+
+
+# ── Output helpers ────────────────────────────────────────────────────────────
+
+
+def _section(title: str, subtitle: str = "") -> None:
+    header = Text()
+    header.append(title, style="bold cyan")
+    if subtitle:
+        header.append(f"\n{subtitle}", style="dim")
+    console.print(Panel(header, box=box.ROUNDED, border_style="cyan", padding=(0, 2)))
+
+
+def _add_row(table: Table, s: OHLCVBar, d: OHLCVBar) -> None:
+    date = convert_timestamp_to_iso(s.timestamp)[:10]
+    ratio = d.close / s.close if s.close else 0.0
+    delta = d.close - s.close
+    ratio_style = "green" if ratio >= 1.0 else "red"
+    table.add_row(
+        date,
+        f"{s.close:.3f}",
+        f"{d.close:.5f}",
+        Text(f"{ratio:.4f}", style=ratio_style),
+        Text(f"{delta:+.3f}", style=ratio_style),
+    )
+
+
+def _render_comparison(
+    splits_bars: list[OHLCVBar],
+    div_bars: list[OHLCVBar],
+    *,
+    head: int = 5,
+    tail: int = 5,
+) -> None:
+    """Render a Rich table comparing split-adjusted vs dividend-adjusted closes."""
+    table = Table(box=box.SIMPLE_HEAD, show_edge=False, padding=(0, 1))
+    table.add_column("Date", style="bold", min_width=12)
+    table.add_column("Splits-Adj", justify="right", min_width=12)
+    table.add_column("Dividend-Adj", justify="right", min_width=14)
+    table.add_column("Ratio", justify="right", min_width=8)
+    table.add_column("Delta", justify="right", min_width=10)
+
+    paired = list(zip(splits_bars, div_bars, strict=False))
+    total = len(paired)
+    cutoff = head + tail
+
+    rows_to_show = paired[:head] if total > cutoff else paired
+    for s, d in rows_to_show:
+        _add_row(table, s, d)
+
+    if total > cutoff:
+        table.add_row(Text(f"  … {total - cutoff} bars omitted …", style="dim"), "", "", "", "")
+        for s, d in paired[-tail:]:
+            _add_row(table, s, d)
+
+    console.print(table)
+
+
+def _print_count_summary(splits_bars: list[OHLCVBar], div_bars: list[OHLCVBar]) -> None:
+    first_s, first_d = splits_bars[0].close, div_bars[0].close
+    last_s, last_d = splits_bars[-1].close, div_bars[-1].close
+    first_ratio = first_d / first_s if first_s else 0.0
+    last_ratio = last_d / last_s if last_s else 0.0
+
+    summary = Table.grid(padding=(0, 2))
+    summary.add_column(style="dim")
+    summary.add_column()
+    summary.add_row("Oldest bar ratio (div-adj / splits):", f"{first_ratio:.4f}")
+    summary.add_row("Newest bar ratio (div-adj / splits):", f"{last_ratio:.4f}")
+    summary.add_row(
+        "Interpretation:",
+        "Ratio < 1.0 means historical prices are lower in the dividend-adjusted "
+        "series (dividends deducted backward).",
+    )
+    console.print()
+    console.print(summary)
+
+
+# ── Demo functions ────────────────────────────────────────────────────────────
+
+
+async def run_count_mode(symbol: str, interval: str, bars_count: int) -> None:
+    """Fetch and compare bars_count most-recent bars in both adjustment modes."""
+    _section(
+        "Count Mode Comparison",
+        f"{bars_count} most-recent {interval} bars · {symbol} · splits vs dividend-adjusted",
+    )
+
+    async with OHLCV() as client:
+        splits_bars = await client.get_historical_ohlcv(
+            exchange_symbol=symbol,
+            interval=interval,
+            bars_count=bars_count,
+            adjustment=Adjustment.SPLITS,
+        )
+        div_bars = await client.get_historical_ohlcv(
+            exchange_symbol=symbol,
+            interval=interval,
+            bars_count=bars_count,
+            adjustment=Adjustment.DIVIDENDS,
+        )
+
+    if not splits_bars or not div_bars:
+        console.print("  [yellow]⚠[/yellow]  No bars returned — check the symbol and interval.")
+        return
+
+    _render_comparison(splits_bars, div_bars, head=5, tail=5)
+    _print_count_summary(splits_bars, div_bars)
+
+
+async def run_range_mode(symbol: str, interval: str, start: str, end: str) -> None:
+    """Fetch dividend-adjusted bars for a specific date window."""
+    _section(
+        "Range Mode — Dividend-Adjusted",
+        f"{symbol} · {start} → {end} · {interval} bars",
+    )
+
+    try:
+        async with OHLCV() as client:
+            div_bars = await client.get_historical_ohlcv(
+                exchange_symbol=symbol,
+                interval=interval,
+                start=start,
+                end=end,
+                adjustment=Adjustment.DIVIDENDS,
+            )
+    except NoHistoricalDataError:
+        console.print(
+            "  [yellow]⚠[/yellow]  No historical data for this range in anonymous mode. "
+            "Authenticate with an account to access older data."
+        )
+        return
+
+    if not div_bars:
+        console.print("  [yellow]⚠[/yellow]  No bars returned.")
+        return
+
+    first_date = convert_timestamp_to_iso(div_bars[0].timestamp)[:10]
+    last_date = convert_timestamp_to_iso(div_bars[-1].timestamp)[:10]
+
+    info = Table.grid(padding=(0, 2))
+    info.add_column(style="dim")
+    info.add_column()
+    info.add_row("Bars received:", str(len(div_bars)))
+    info.add_row("Date range:", f"{first_date} → {last_date}")
+    info.add_row("First bar close (div-adj):", f"{div_bars[0].close:.5f}")
+    info.add_row("Last bar close  (div-adj):", f"{div_bars[-1].close:.5f}")
+    console.print(info)
+
+
+def show_adjustment_reference() -> None:
+    """Display the Adjustment enum members and their protocol values."""
+    _section(
+        "Adjustment Enum Reference",
+        "Protocol values sent in the TradingView WebSocket resolve_symbol message",
+    )
+
+    table = Table(box=box.SIMPLE_HEAD, show_edge=False, padding=(0, 1))
+    table.add_column("Enum member", style="bold cyan", min_width=24)
+    table.add_column("Protocol value", min_width=14)
+    table.add_column("Description", min_width=50)
+
+    table.add_row(
+        "Adjustment.SPLITS",
+        Text('"splits"', style="dim"),
+        "Split-adjusted only — default, backwards-compatible with all pre-v0.11.0 calls",
+    )
+    table.add_row(
+        "Adjustment.DIVIDENDS",
+        Text('"dividends"', style="dim"),
+        "Dividend-adjusted (total-return) — prior prices backward-adjusted for cash dividends",
+    )
+
+    console.print(table)
+    console.print()
+    note = Table.grid(padding=(0, 1))
+    note.add_column(style="dim")
+    note.add_column()
+    note.add_row(
+        "Note:",
+        "Adjustment.NONE (raw unadjusted prices) is not yet supported — "
+        "protocol value not confirmed; tracked for a future release.",
+    )
+    console.print(note)
+
+
+# ── Menu helpers ──────────────────────────────────────────────────────────────
+
+
+def _prompt_symbol() -> str:
+    return (
+        Prompt.ask(
+            "  [bold]Symbol[/bold] [dim](e.g. NASDAQ:AAPL, SET:ADVANC)[/dim]",
+            default=DEFAULT_SYMBOL,
+        )
+        .strip()
+        .upper()
+    )
+
+
+def _prompt_interval() -> str:
+    return Prompt.ask(
+        "  [bold]Interval[/bold] [dim](1, 5, 15, 60, 1H, 1D, 1W, 1M)[/dim]",
+        default=DEFAULT_INTERVAL,
+    ).strip()
+
+
+def _print_menu() -> None:
+    menu = Table.grid(padding=(0, 2))
+    menu.add_column(style="bold cyan", min_width=4)
+    menu.add_column()
+    menu.add_row("1", "Preset demo — SET:ADVANC 1D · 300 bars · splits vs dividend-adjusted")
+    menu.add_row("2", "Custom symbol — count mode (N most-recent bars)")
+    menu.add_row("3", "Custom symbol — range mode (date window, dividend-adjusted)")
+    menu.add_row("4", "Show Adjustment enum reference")
+    menu.add_row("5", "Exit")
+    console.print(menu)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+async def main() -> None:
+    console.print()
+    console.print(
+        Panel(
+            "[bold white]Dividend-Adjusted OHLCV — tvkit[/bold white]\n"
+            "[dim]Compare split-adjusted vs total-return prices using the Adjustment enum[/dim]",
+            box=box.DOUBLE_EDGE,
+            border_style="bright_blue",
+            padding=(1, 4),
+        )
+    )
+
+    while True:
+        console.print()
+        _print_menu()
+        console.print()
+        choice = Prompt.ask(
+            "  [bold]Select[/bold]",
+            choices=["1", "2", "3", "4", "5"],
+            default="1",
+        )
+        console.print()
+
+        if choice == "1":
+            await run_count_mode(
+                symbol=DEFAULT_SYMBOL,
+                interval=DEFAULT_INTERVAL,
+                bars_count=DEFAULT_COUNT_BARS,
+            )
+
+        elif choice == "2":
+            symbol = _prompt_symbol()
+            interval = _prompt_interval()
+            bars_count = IntPrompt.ask(
+                "  [bold]Bars count[/bold]",
+                default=DEFAULT_COUNT_BARS,
+            )
+            console.print()
+            await run_count_mode(symbol=symbol, interval=interval, bars_count=bars_count)
+
+        elif choice == "3":
+            symbol = _prompt_symbol()
+            interval = _prompt_interval()
+            start = Prompt.ask(
+                "  [bold]Start date[/bold] [dim](YYYY-MM-DD)[/dim]",
+                default="2025-01-01",
+            ).strip()
+            end = Prompt.ask(
+                "  [bold]End date[/bold]   [dim](YYYY-MM-DD)[/dim]",
+                default="2025-12-31",
+            ).strip()
+            console.print()
+            await run_range_mode(symbol=symbol, interval=interval, start=start, end=end)
+
+        elif choice == "4":
+            show_adjustment_reference()
+
+        elif choice == "5":
+            console.print("[bold green]Goodbye.[/bold green]")
+            break
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvkit"
-version = "0.10.0"
+version = "0.11.0"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_adjustment_enum.py
+++ b/tests/test_adjustment_enum.py
@@ -1,0 +1,70 @@
+"""Unit tests for the Adjustment enum contract."""
+
+import pytest
+
+from tvkit.api.chart import Adjustment
+from tvkit.api.chart.models.adjustment import Adjustment as AdjDirect
+
+
+def test_adjustment_importable_from_chart_package() -> None:
+    """Adjustment is accessible from the public tvkit.api.chart surface."""
+    assert Adjustment.SPLITS
+
+
+def test_adjustment_splits_value() -> None:
+    """SPLITS.value must equal the TradingView protocol string 'splits'."""
+    assert Adjustment.SPLITS.value == "splits"
+
+
+def test_adjustment_dividends_value() -> None:
+    """DIVIDENDS.value must equal the TradingView protocol string 'dividends'."""
+    assert Adjustment.DIVIDENDS.value == "dividends"
+
+
+def test_adjustment_is_str_enum() -> None:
+    """Adjustment members must be str instances for direct JSON embedding."""
+    assert isinstance(Adjustment.SPLITS, str)
+    assert isinstance(Adjustment.DIVIDENDS, str)
+
+
+def test_adjustment_coercion_splits() -> None:
+    """Adjustment('splits') must coerce to Adjustment.SPLITS."""
+    assert Adjustment("splits") == Adjustment.SPLITS
+
+
+def test_adjustment_coercion_dividends() -> None:
+    """Adjustment('dividends') must coerce to Adjustment.DIVIDENDS."""
+    assert Adjustment("dividends") == Adjustment.DIVIDENDS
+
+
+def test_adjustment_coercion_invalid_string_raises_value_error() -> None:
+    """Unknown adjustment strings must raise ValueError."""
+    with pytest.raises(ValueError):
+        Adjustment("none")
+
+
+def test_adjustment_coercion_empty_string_raises_value_error() -> None:
+    """Empty string must raise ValueError."""
+    with pytest.raises(ValueError):
+        Adjustment("")
+
+
+def test_adjustment_direct_import_matches_package_import() -> None:
+    """Direct module import and package-level import must resolve to the same class."""
+    assert Adjustment.SPLITS is AdjDirect.SPLITS
+    assert Adjustment.DIVIDENDS is AdjDirect.DIVIDENDS
+
+
+def test_adjustment_str_equality() -> None:
+    """As a str enum, Adjustment.SPLITS == 'splits' must hold."""
+    assert Adjustment.SPLITS == "splits"
+    assert Adjustment.DIVIDENDS == "dividends"
+
+
+@pytest.mark.parametrize("adj", [Adjustment.SPLITS, Adjustment.DIVIDENDS])
+def test_adjustment_value_is_json_serializable(adj: Adjustment) -> None:
+    """Each member's .value must be usable directly in json.dumps contexts."""
+    import json
+
+    payload = json.dumps({"adjustment": adj.value})
+    assert adj.value in payload

--- a/tests/test_connection_service.py
+++ b/tests/test_connection_service.py
@@ -321,6 +321,76 @@ class TestAuthErrorDetection:
         # WebSocket close() was invoked during teardown
         ws_mock.close.assert_called()
 
+    # ── Adjustment / backadjustment tests (Phase 1) ──────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_resolve_symbol_includes_backadjustment_default(self) -> None:
+        """resolve_symbol payload must include backadjustment:'default' in default/splits mode."""
+        sent: list[tuple[str, list[Any]]] = []
+
+        async def mock_send(m: str, p: list[Any]) -> None:
+            sent.append((m, p))
+
+        svc = ConnectionService(ws_url=WS_URL)
+        await svc.add_symbol_to_sessions("qs_t", "cs_t", "NASDAQ:AAPL", "1D", 100, mock_send)
+        resolve_args = next(p for m, p in sent if m == "resolve_symbol")
+        payload = json.loads(resolve_args[2].lstrip("="))
+        assert payload["backadjustment"] == "default"
+        assert payload["adjustment"] == "splits"
+
+    @pytest.mark.asyncio
+    async def test_resolve_symbol_dividends_adjustment(self) -> None:
+        """Passing Adjustment.DIVIDENDS must produce adjustment:'dividends' in resolve_symbol."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        sent: list[tuple[str, list[Any]]] = []
+
+        async def mock_send(m: str, p: list[Any]) -> None:
+            sent.append((m, p))
+
+        svc = ConnectionService(ws_url=WS_URL)
+        await svc.add_symbol_to_sessions(
+            "qs_t",
+            "cs_t",
+            "SET:ADVANC",
+            "1D",
+            300,
+            mock_send,
+            adjustment=Adjustment.DIVIDENDS,
+        )
+        resolve_args = next(p for m, p in sent if m == "resolve_symbol")
+        payload = json.loads(resolve_args[2].lstrip("="))
+        assert payload["adjustment"] == "dividends"
+        assert payload["backadjustment"] == "default"
+
+    def test_add_symbol_to_sessions_default_adjustment_is_splits(self) -> None:
+        """Default value of adjustment parameter must be Adjustment.SPLITS."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        sig = inspect.signature(ConnectionService.add_symbol_to_sessions)
+        assert sig.parameters["adjustment"].default == Adjustment.SPLITS
+
+    @pytest.mark.parametrize("adj_str", ["splits", "dividends"])
+    @pytest.mark.asyncio
+    async def test_backadjustment_present_for_all_adjustment_types(self, adj_str: str) -> None:
+        """backadjustment:'default' must be in resolve_symbol for every Adjustment value."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        sent: list[tuple[str, list[Any]]] = []
+
+        async def mock_send(m: str, p: list[Any]) -> None:
+            sent.append((m, p))
+
+        adj = Adjustment(adj_str)
+        svc = ConnectionService(ws_url=WS_URL)
+        await svc.add_symbol_to_sessions(
+            "qs_t", "cs_t", "NASDAQ:AAPL", "1D", 100, mock_send, adjustment=adj
+        )
+        resolve_args = next(p for m, p in sent if m == "resolve_symbol")
+        payload = json.loads(resolve_args[2].lstrip("="))
+        assert payload["backadjustment"] == "default"
+        assert payload["adjustment"] == adj_str
+
     def test_auth_error_is_subclass_of_chart_error(self) -> None:
         """AuthError inherits from ChartError."""
         from tvkit.api.chart.exceptions import ChartError

--- a/tests/test_historical_ohlcv.py
+++ b/tests/test_historical_ohlcv.py
@@ -800,8 +800,10 @@ class TestSessionLifecycle:
         with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
             await client.get_historical_ohlcv(exchange_symbol=SYMBOL, interval="1D", bars_count=5)
 
+        from tvkit.api.chart.models.adjustment import Adjustment
+
         client._prepare_chart_session.assert_called_once_with(  # type: ignore[union-attr]
-            SYMBOL, "1D", 5, range_param=""
+            SYMBOL, "1D", 5, range_param="", adjustment=Adjustment.SPLITS
         )
 
     @pytest.mark.asyncio
@@ -1327,3 +1329,164 @@ class TestSegmentationDispatch:
         client._fetch_single_range.assert_called_once()  # type: ignore[union-attr]
         mock_fetch_all.assert_not_called()
         assert result == [expected_bar]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Adjustment parameter tests (Phase 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSessionLifecycleAdjustment:
+    """Adjustment propagation through get_historical_ohlcv → _prepare_chart_session."""
+
+    @pytest.mark.asyncio
+    async def test_default_adjustment_is_splits(self) -> None:
+        """Omitting adjustment must forward Adjustment.SPLITS to _prepare_chart_session."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        messages: list[dict[str, Any]] = [make_timescale_update(bars_count=5), SERIES_COMPLETED_MSG]
+        client = _make_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            await client.get_historical_ohlcv(exchange_symbol=SYMBOL, interval="1D", bars_count=5)
+
+        _, kwargs = client._prepare_chart_session.call_args  # type: ignore[union-attr]
+        assert kwargs.get("adjustment") == Adjustment.SPLITS
+
+    @pytest.mark.asyncio
+    async def test_dividends_adjustment_forwarded(self) -> None:
+        """Passing Adjustment.DIVIDENDS must forward it to _prepare_chart_session."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        messages: list[dict[str, Any]] = [make_timescale_update(bars_count=5), SERIES_COMPLETED_MSG]
+        client = _make_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            await client.get_historical_ohlcv(
+                exchange_symbol=SYMBOL,
+                interval="1D",
+                bars_count=5,
+                adjustment=Adjustment.DIVIDENDS,
+            )
+
+        _, kwargs = client._prepare_chart_session.call_args  # type: ignore[union-attr]
+        assert kwargs.get("adjustment") == Adjustment.DIVIDENDS
+
+    @pytest.mark.asyncio
+    async def test_raw_string_dividends_coerced(self) -> None:
+        """Passing adjustment='dividends' as a raw str must coerce without error."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        messages: list[dict[str, Any]] = [make_timescale_update(bars_count=5), SERIES_COMPLETED_MSG]
+        client = _make_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            await client.get_historical_ohlcv(
+                exchange_symbol=SYMBOL,
+                interval="1D",
+                bars_count=5,
+                adjustment="dividends",  # type: ignore[arg-type]
+            )
+
+        _, kwargs = client._prepare_chart_session.call_args  # type: ignore[union-attr]
+        assert kwargs.get("adjustment") == Adjustment.DIVIDENDS
+
+    @pytest.mark.asyncio
+    async def test_invalid_adjustment_string_raises_value_error_before_io(self) -> None:
+        """Unknown adjustment string must raise ValueError before any I/O."""
+        messages: list[dict[str, Any]] = []
+        client = _make_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            with pytest.raises(ValueError):
+                await client.get_historical_ohlcv(
+                    exchange_symbol=SYMBOL,
+                    interval="1D",
+                    bars_count=5,
+                    adjustment="none",  # type: ignore[arg-type]
+                )
+
+        client._prepare_chart_session.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_get_ohlcv_calls_prepare_with_splits_default(self) -> None:
+        """Regression: get_ohlcv() does not expose adjustment; _prepare_chart_session receives SPLITS."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        client: OHLCV = OHLCV()
+        prepare_mock: AsyncMock = AsyncMock()
+        client._prepare_chart_session = prepare_mock  # type: ignore[method-assign]
+        client.connection_service = MagicMock()
+        client.connection_service.get_data_stream = lambda: fake_stream([])
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            async for _ in client.get_ohlcv(exchange_symbol=SYMBOL, interval="1D", bars_count=5):
+                break  # exhaust one iteration so _prepare_chart_session is called
+
+        if prepare_mock.called:
+            _, kwargs = prepare_mock.call_args
+            assert kwargs.get("adjustment", Adjustment.SPLITS) == Adjustment.SPLITS
+
+
+class TestRangeModeAdjustment:
+    """Adjustment propagation in get_historical_ohlcv() range mode."""
+
+    @pytest.mark.asyncio
+    async def test_range_mode_passes_dividends_adjustment(self) -> None:
+        """adjustment=Adjustment.DIVIDENDS must propagate in range mode."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        messages: list[dict[str, Any]] = [
+            SERIES_COMPLETED_MSG,
+            make_range_timescale_update(bars_count=3),
+            SERIES_COMPLETED_MSG,
+        ]
+        prepare_mock: AsyncMock = AsyncMock()
+        client: OHLCV = OHLCV()
+        client._prepare_chart_session = prepare_mock  # type: ignore[method-assign]
+        client.connection_service = MagicMock()
+        client.connection_service.get_data_stream = lambda: fake_stream(messages)
+        client.connection_service.close = AsyncMock()
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **make_patches()):
+            await client.get_historical_ohlcv(
+                exchange_symbol=SYMBOL,
+                interval="1D",
+                start="2024-01-01",
+                end="2024-12-31",
+                adjustment=Adjustment.DIVIDENDS,
+            )
+
+        _, kwargs = prepare_mock.call_args
+        assert kwargs.get("adjustment") == Adjustment.DIVIDENDS
+
+
+class TestStreamingSessionAdjustment:
+    """_StreamingSession must store and default adjustment correctly."""
+
+    def test_streaming_session_defaults_to_splits(self) -> None:
+        """Omitting adjustment from _StreamingSession must default to Adjustment.SPLITS."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        s = _StreamingSession(
+            symbol=SYMBOL,
+            interval="1D",
+            bars_count=100,
+            quote_session="qs_x",
+            chart_session="cs_x",
+        )
+        assert s.adjustment == Adjustment.SPLITS
+
+    def test_streaming_session_stores_dividends(self) -> None:
+        """_StreamingSession must store Adjustment.DIVIDENDS when provided."""
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        s = _StreamingSession(
+            symbol="SET:ADVANC",
+            interval="1D",
+            bars_count=300,
+            quote_session="qs_x",
+            chart_session="cs_x",
+            adjustment=Adjustment.DIVIDENDS,
+        )
+        assert s.adjustment == Adjustment.DIVIDENDS

--- a/tests/test_ohlcv_reconnect.py
+++ b/tests/test_ohlcv_reconnect.py
@@ -128,8 +128,17 @@ class TestRestoreSession:
         mock_ms_cls.assert_called_once_with(mock_ws)
         assert client.message_service is mock_ms  # assignment happened
         mock_cs.initialize_sessions.assert_called_once_with("qs_abc", "cs_abc", mock_send)
+        from tvkit.api.chart.models.adjustment import Adjustment
+
         mock_cs.add_symbol_to_sessions.assert_called_once_with(
-            "qs_abc", "cs_abc", "NASDAQ:AAPL", "1D", 100, mock_send, range_param=""
+            "qs_abc",
+            "cs_abc",
+            "NASDAQ:AAPL",
+            "1D",
+            100,
+            mock_send,
+            range_param="",
+            adjustment=Adjustment.SPLITS,
         )
 
     @pytest.mark.asyncio
@@ -157,6 +166,8 @@ class TestRestoreSession:
         with patch("tvkit.api.chart.ohlcv.MessageService", return_value=mock_ms):
             await client._restore_session()
 
+        from tvkit.api.chart.models.adjustment import Adjustment
+
         mock_cs.add_symbol_to_sessions.assert_called_once_with(
             "qs_abc",
             "cs_abc",
@@ -165,6 +176,7 @@ class TestRestoreSession:
             5000,
             mock_send,
             range_param="r,1704067200:1735603200",
+            adjustment=Adjustment.SPLITS,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_ohlcv_symbol_integration.py
+++ b/tests/test_ohlcv_symbol_integration.py
@@ -70,8 +70,12 @@ class TestNormalizeBeforeValidate:
             with pytest.raises(RuntimeError, match="No historical data"):
                 await client._fetch_count_mode("nasdaq:aapl", "1D", bars_count=5)
 
+            from tvkit.api.chart.models.adjustment import Adjustment
+
             mock_validate.assert_called_once_with("NASDAQ:AAPL")
-            mock_prepare.assert_called_once_with("NASDAQ:AAPL", "1D", 5, range_param="")
+            mock_prepare.assert_called_once_with(
+                "NASDAQ:AAPL", "1D", 5, range_param="", adjustment=Adjustment.SPLITS
+            )
 
     @pytest.mark.asyncio
     async def test_fetch_count_mode_dash_notation_passed_canonical(self) -> None:

--- a/tests/test_segmented_fetch.py
+++ b/tests/test_segmented_fetch.py
@@ -409,6 +409,36 @@ class TestRecursionGuard:
         mock_client._fetch_single_range.assert_called()
         mock_client.get_historical_ohlcv.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_fetch_all_forwards_dividends_adjustment_to_each_segment(self) -> None:
+        """fetch_all() must forward adjustment to every _fetch_single_range call."""
+
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        mock_client = AsyncMock(spec=OHLCV)
+        mock_client._fetch_single_range = AsyncMock(return_value=[make_bar(1000.0)])
+        service = SegmentedFetchService(client=mock_client)
+
+        await service.fetch_all(
+            "SET:ADVANC",
+            "1H",
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 1, 2, tzinfo=UTC),
+            adjustment=Adjustment.DIVIDENDS,
+        )
+
+        for call in mock_client._fetch_single_range.call_args_list:
+            assert call.kwargs.get("adjustment") == Adjustment.DIVIDENDS
+
+    def test_fetch_all_default_adjustment_is_splits(self) -> None:
+        """Omitting adjustment from fetch_all() must default to Adjustment.SPLITS."""
+        import inspect as _inspect
+
+        from tvkit.api.chart.models.adjustment import Adjustment
+
+        sig = _inspect.signature(SegmentedFetchService.fetch_all)
+        assert sig.parameters["adjustment"].default == Adjustment.SPLITS
+
 
 # ---------------------------------------------------------------------------
 # TestSegmentedFetchMaxBarsSnapshot  (Phase 5)

--- a/tvkit/api/chart/__init__.py
+++ b/tvkit/api/chart/__init__.py
@@ -7,6 +7,7 @@ from TradingView, including OHLCV data, trade information, and technical indicat
 
 from .exceptions import AuthError, ChartError, RangeTooLargeError, StreamConnectionError
 from .models import (
+    Adjustment,
     ExportConfig,
     IndicatorData,
     OHLCVData,
@@ -23,6 +24,8 @@ from .ohlcv import OHLCV
 __all__ = [
     # Main streamer class
     "OHLCV",
+    # Enums
+    "Adjustment",
     # Exceptions
     "AuthError",
     "ChartError",

--- a/tvkit/api/chart/models/__init__.py
+++ b/tvkit/api/chart/models/__init__.py
@@ -5,6 +5,7 @@ This module provides type-safe data models for all real-time streaming
 operations including OHLCV data, trade information, and WebSocket messages.
 """
 
+from .adjustment import Adjustment
 from .ohlcv import (
     LastBarStatus,
     NamespaceData,
@@ -31,6 +32,7 @@ from .stream_models import (
 )
 
 __all__ = [
+    "Adjustment",
     "OHLCVData",
     "TradeData",
     "StreamConfig",

--- a/tvkit/api/chart/models/adjustment.py
+++ b/tvkit/api/chart/models/adjustment.py
@@ -1,0 +1,43 @@
+"""TradingView price adjustment mode enum for OHLCV data."""
+
+from enum import Enum
+
+
+class Adjustment(str, Enum):
+    """TradingView price adjustment mode for OHLCV data.
+
+    Controls how historical prices are adjusted for corporate actions.
+    Maps directly to the ``adjustment`` field in TradingView's
+    ``resolve_symbol`` WebSocket message.
+
+    Being a ``str`` subclass, each member serialises directly to its
+    string value — ``Adjustment.DIVIDENDS.value == "dividends"`` — so
+    it can be embedded in ``json.dumps`` calls without a custom encoder.
+
+    Usage::
+
+        from tvkit.api.chart import Adjustment
+
+        bars = await client.get_historical_ohlcv(
+            "SET:ADVANC", "1D", bars_count=300,
+            adjustment=Adjustment.DIVIDENDS,
+        )
+    """
+
+    SPLITS = "splits"
+    """Split-adjusted prices only.
+
+    Default — backwards-compatible with all calls that omit the
+    ``adjustment`` parameter.  Only forward stock splits and reverse
+    splits are reflected in historical prices.
+    """
+
+    DIVIDENDS = "dividends"
+    """Dividend-adjusted (total-return) prices.
+
+    Both splits and cash dividends are reflected backwards in historical
+    prices.  Each dividend payment is subtracted from all prior closing
+    prices so the series represents the total return of holding the stock
+    continuously.  Use for accurate long-term backtesting of
+    dividend-paying stocks.
+    """

--- a/tvkit/api/chart/ohlcv.py
+++ b/tvkit/api/chart/ohlcv.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from tvkit.api.chart.exceptions import NoHistoricalDataError
+from tvkit.api.chart.models.adjustment import Adjustment
 from tvkit.api.chart.models.ohlcv import (
     OHLCVBar,
     OHLCVResponse,
@@ -98,6 +99,9 @@ class _StreamingSession:
         quote_session: Quote session identifier (e.g. "qs_abc123").
         chart_session: Chart session identifier (e.g. "cs_abc123").
         range_param: TradingView range string if range mode, else "".
+        adjustment: Price adjustment mode. Stored so that ``_restore_session``
+            replays the correct adjustment type after a WebSocket reconnect.
+            Defaults to ``Adjustment.SPLITS`` (identical to pre-v0.11.0 behaviour).
     """
 
     symbol: str
@@ -106,6 +110,7 @@ class _StreamingSession:
     quote_session: str
     chart_session: str
     range_param: str = ""
+    adjustment: Adjustment = Adjustment.SPLITS
 
 
 # Timeout constants for get_historical_ohlcv().
@@ -425,6 +430,7 @@ class OHLCV:
                 session.bars_count,
                 send_message_func,
                 range_param=session.range_param,
+                adjustment=session.adjustment,
             )
         except Exception:
             logger.exception(
@@ -444,6 +450,7 @@ class OHLCV:
         bars_count: int,
         *,
         range_param: str = "",
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> None:
         """
         Set up services and subscribe the chart session to symbol data.
@@ -458,6 +465,9 @@ class OHLCV:
             range_param: TradingView range string (e.g. "r,<from>:<to>"). If non-empty,
                 a modify_series message is sent immediately after create_series to apply
                 the date range constraint. Empty string means count mode (default).
+            adjustment: Price adjustment mode forwarded to ``add_symbol_to_sessions()``.
+                Defaults to ``Adjustment.SPLITS``. Stored in ``_StreamingSession`` so
+                that ``_restore_session`` replays the correct type after reconnect.
 
         Raises:
             RuntimeError: If services fail to initialize.
@@ -482,6 +492,7 @@ class OHLCV:
             bars_count,
             send_message_func,
             range_param=range_param,
+            adjustment=adjustment,
         )
         self._session = _StreamingSession(
             symbol=converted_symbol,
@@ -490,6 +501,7 @@ class OHLCV:
             quote_session=quote_session,
             chart_session=chart_session,
             range_param=range_param,
+            adjustment=adjustment,
         )
 
     def _validate_range(self, start: datetime, end: datetime) -> tuple[datetime, datetime]:
@@ -576,6 +588,7 @@ class OHLCV:
         *,
         start: datetime,
         end: datetime,
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> list[OHLCVBar]:
         """
         Perform a single-request historical fetch using range mode.
@@ -597,6 +610,8 @@ class OHLCV:
             interval:        TradingView interval string.
             start:           Inclusive start of the range (UTC-aware datetime, keyword-only).
             end:             Inclusive end of the range (UTC-aware datetime, keyword-only).
+            adjustment:      Price adjustment mode forwarded to ``_prepare_chart_session()``.
+                             Defaults to ``Adjustment.SPLITS``.
 
         Returns:
             List of OHLCVBar objects, sorted ascending by timestamp.
@@ -614,7 +629,7 @@ class OHLCV:
 
         range_param: str = build_range_param(start, end)
         await self._prepare_chart_session(
-            canonical, interval, MAX_BARS_REQUEST, range_param=range_param
+            canonical, interval, MAX_BARS_REQUEST, range_param=range_param, adjustment=adjustment
         )
 
         if self.connection_service is None:
@@ -802,6 +817,7 @@ class OHLCV:
         interval: str,
         *,
         bars_count: int,
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> list[OHLCVBar]:
         """
         Perform a count-based historical fetch (most recent N bars).
@@ -814,6 +830,8 @@ class OHLCV:
             exchange_symbol: TradingView symbol in EXCHANGE:SYMBOL format.
             interval:        TradingView interval string.
             bars_count:      Number of bars to fetch (keyword-only). Must be > 0.
+            adjustment:      Price adjustment mode forwarded to ``_prepare_chart_session()``.
+                             Defaults to ``Adjustment.SPLITS``.
 
         Returns:
             List of OHLCVBar objects, sorted ascending by timestamp.
@@ -827,7 +845,9 @@ class OHLCV:
         await validate_symbols(canonical)
         validate_interval(interval)
 
-        await self._prepare_chart_session(canonical, interval, bars_count, range_param="")
+        await self._prepare_chart_session(
+            canonical, interval, bars_count, range_param="", adjustment=adjustment
+        )
 
         if self.connection_service is None:
             raise RuntimeError("Services not properly initialized")
@@ -1148,6 +1168,7 @@ class OHLCV:
         *,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> list[OHLCVBar]:
         """
         Returns a list of historical OHLCV data for a specified symbol.
@@ -1162,6 +1183,13 @@ class OHLCV:
 
             bars = await client.get_historical_ohlcv(
                 "NASDAQ:AAPL", "1D", start="2024-01-01", end="2024-12-31"
+            )
+
+        **Dividend-adjusted prices:**
+
+            bars = await client.get_historical_ohlcv(
+                "SET:ADVANC", "1D", bars_count=300,
+                adjustment=Adjustment.DIVIDENDS,
             )
 
         For large date ranges in range mode, this method automatically splits the request
@@ -1183,6 +1211,13 @@ class OHLCV:
             end: End of the date range (inclusive). Same accepted types as start.
                 Keyword-only. Must be provided together with start. Future end dates
                 are automatically clamped to the current UTC time.
+            adjustment: Price adjustment mode. Keyword-only. Defaults to
+                ``Adjustment.SPLITS`` — fully backwards-compatible; all existing calls
+                that omit this parameter produce the same data as before v0.11.0.
+                Pass ``Adjustment.DIVIDENDS`` for total-return (dividend-adjusted)
+                prices. Raw strings (``"splits"``, ``"dividends"``) are accepted and
+                coerced to the enum; unknown strings raise ``ValueError`` before any
+                network I/O.
 
         Returns:
             A list of OHLCVBar objects sorted by timestamp in ascending order.
@@ -1190,7 +1225,8 @@ class OHLCV:
         Raises:
             ValueError: If neither bars_count nor start/end is provided; if both are
                 provided; if only one of start/end is provided; if bars_count <= 0;
-                if start > end; or if the symbol/interval is invalid.
+                if start > end; if the symbol/interval is invalid; or if ``adjustment``
+                is an unrecognised string value.
             RangeTooLargeError: If the date range requires more than MAX_SEGMENTS (2000)
                 fetch operations. Narrow the range or use a wider interval.
             RuntimeError: If no bars are received from TradingView (count mode).
@@ -1198,6 +1234,10 @@ class OHLCV:
                 This is a RuntimeError subclass — existing except RuntimeError callers
                 are unaffected.
         """
+        # Coerce raw strings ("dividends") to Adjustment; unknown strings raise ValueError
+        # here, at the API boundary, before any I/O. Must be the first statement.
+        adjustment = Adjustment(adjustment)
+
         # --- Mode dispatch (fail fast before WebSocket) ---
         has_range: bool = start is not None or end is not None
         has_count: bool = bars_count is not None
@@ -1239,16 +1279,20 @@ class OHLCV:
                     client=self,
                     max_bars_per_segment=MAX_BARS_REQUEST,
                 )
-                return await service.fetch_all(exchange_symbol, interval, start_dt, end_dt)
+                return await service.fetch_all(
+                    exchange_symbol, interval, start_dt, end_dt, adjustment=adjustment
+                )
 
             # Small range — use single-request path (existing behavior, unchanged).
             return await self._fetch_single_range(
-                exchange_symbol, interval, start=start_dt, end=end_dt
+                exchange_symbol, interval, start=start_dt, end=end_dt, adjustment=adjustment
             )
 
         elif has_count:
             assert bars_count is not None  # mypy narrowing
-            return await self._fetch_count_mode(exchange_symbol, interval, bars_count=bars_count)
+            return await self._fetch_count_mode(
+                exchange_symbol, interval, bars_count=bars_count, adjustment=adjustment
+            )
 
         else:
             raise ValueError("Either bars_count or both start and end must be provided.")

--- a/tvkit/api/chart/services/connection_service.py
+++ b/tvkit/api/chart/services/connection_service.py
@@ -14,6 +14,7 @@ from websockets.connection import State as WebSocketState
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
 from tvkit.api.chart.exceptions import AuthError, StreamConnectionError
+from tvkit.api.chart.models.adjustment import Adjustment
 from tvkit.api.chart.models.realtime import (
     ExtraRequestHeader,
     WebSocketConnection,
@@ -583,6 +584,7 @@ class ConnectionService:
         send_message_func: Callable[[str, list[Any]], Awaitable[None]],
         *,
         range_param: str = "",
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> None:
         """
         Adds the specified symbol to the quote and chart sessions.
@@ -600,18 +602,31 @@ class ConnectionService:
         build_range_param() produces a validated string before passing it here.
 
         Args:
-            quote_session: The quote session identifier
-            chart_session: The chart session identifier
-            exchange_symbol: The symbol in 'EXCHANGE:SYMBOL' format
-            timeframe: The timeframe for the chart (default is "1")
-            bars_count: Number of bars to fetch for the chart
-            send_message_func: Function to send messages through the WebSocket
-            range_param: TradingView range string ("r,<from_unix>:<to_unix>") for
+            quote_session: The quote session identifier.
+            chart_session: The chart session identifier.
+            exchange_symbol: The symbol in 'EXCHANGE:SYMBOL' format.
+            timeframe: The timeframe for the chart (e.g. ``"1D"``).
+            bars_count: Number of bars to fetch for the chart.
+            send_message_func: Function to send messages through the WebSocket.
+            range_param: TradingView range string (``"r,<from_unix>:<to_unix>"``) for
                 date-range mode. When non-empty, a modify_series message is sent
                 immediately after create_series to apply the date constraint.
-                Defaults to "" (count mode — modify_series is not sent).
+                Defaults to ``""`` (count mode — modify_series is not sent).
+            adjustment: Price adjustment mode. Controls the ``adjustment`` field in
+                the ``resolve_symbol`` WebSocket payload. Defaults to
+                ``Adjustment.SPLITS`` (split-adjusted prices — backwards-compatible
+                with all pre-v0.11.0 behaviour). Pass ``Adjustment.DIVIDENDS`` for
+                total-return (dividend-adjusted) prices. ``backadjustment: "default"``
+                is always included in the payload — present in every TradingView
+                browser request per HAR analysis.
         """
-        resolve_symbol: str = json.dumps({"adjustment": "splits", "symbol": exchange_symbol})
+        resolve_symbol: str = json.dumps(
+            {
+                "adjustment": adjustment.value,
+                "backadjustment": "default",
+                "symbol": exchange_symbol,
+            }
+        )
         await send_message_func("quote_add_symbols", [quote_session, f"={resolve_symbol}"])
         await send_message_func(
             "resolve_symbol", [chart_session, _SYMBOL_REF_ID, f"={resolve_symbol}"]

--- a/tvkit/api/chart/services/segmented_fetch_service.py
+++ b/tvkit/api/chart/services/segmented_fetch_service.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from tvkit.api.chart.exceptions import NoHistoricalDataError, SegmentedFetchError
+from tvkit.api.chart.models.adjustment import Adjustment
 from tvkit.api.chart.models.ohlcv import OHLCVBar
 from tvkit.api.chart.utils import (
     MAX_BARS_REQUEST,
@@ -75,6 +76,8 @@ class SegmentedFetchService:
         interval: str,
         start: datetime,
         end: datetime,
+        *,
+        adjustment: Adjustment = Adjustment.SPLITS,
     ) -> list[OHLCVBar]:
         """
         Fetch all OHLCV bars for the given range by splitting into segments.
@@ -96,6 +99,10 @@ class SegmentedFetchService:
                              before any fetch is attempted.
             start:           Inclusive start of the date range (UTC-aware datetime).
             end:             Inclusive end of the date range (UTC-aware datetime).
+            adjustment:      Price adjustment mode forwarded to each
+                             ``_fetch_single_range()`` call. Defaults to
+                             ``Adjustment.SPLITS`` (backwards-compatible). Pass
+                             ``Adjustment.DIVIDENDS`` for dividend-adjusted prices.
 
         Returns:
             Deduplicated, chronologically sorted list of ``OHLCVBar`` objects.
@@ -182,6 +189,7 @@ class SegmentedFetchService:
                     interval,
                     start=segment.start,
                     end=segment.end,
+                    adjustment=adjustment,
                 )
             except NoHistoricalDataError:
                 # Expected for segments covering weekends, holidays, or illiquid


### PR DESCRIPTION
## Summary

- Adds `Adjustment` enum (`tvkit.api.chart.Adjustment`) with `SPLITS` and `DIVIDENDS` members
- Adds `adjustment` keyword parameter to `get_historical_ohlcv()` — defaults to `Adjustment.SPLITS` (fully backwards-compatible; no changes needed in existing code)
- Adds `backadjustment: "default"` to the historical OHLCV `resolve_symbol` WebSocket payload — protocol correctness fix; matches TradingView browser behaviour confirmed by HAR capture
- Verified against live data: `SET:ADVANC` 1D closes differ by ~10.7% (ratio ≈ 0.8926) in early 2025 between the two adjustment modes

## Usage

```python
from tvkit.api.chart import OHLCV, Adjustment

async with OHLCV() as client:
    # Default — split-adjusted only; identical to all pre-v0.11.0 calls
    bars = await client.get_historical_ohlcv("SET:ADVANC", "1D", bars_count=300)

    # Dividend-adjusted (total-return) prices
    adj_bars = await client.get_historical_ohlcv(
        "SET:ADVANC", "1D", bars_count=300,
        adjustment=Adjustment.DIVIDENDS,
    )
```

## Protocol source

`docs/plans/dividend-adjustment/devidend_adj.har` — Chrome DevTools capture of TradingView chart toggling between split and dividend adjustment modes. `backadjustment: "default"` is present for both adjustment types in every TradingView request; it was missing from tvkit. Only `add_symbol_to_sessions()` (historical OHLCV path) is updated — `add_multiple_symbols_to_sessions()` (quote data) is unchanged.

## Changes by phase

| Phase | Description |
|-------|-------------|
| Phase 1 | `Adjustment` enum, full call-chain wiring, `backadjustment` fix |
| Phase 2 | 27 new/extended tests; 1005 passing, 0 failures |
| Phase 3 | `docs/reference/chart/ohlcv.md` updated; `examples/ohlcv_dividend_adjusted.py` (menu-driven Rich example); `CHANGELOG.md` |
| Phase 4 | Version bump `0.10.0 → 0.11.0`; roadmap update; PyPI publish |

## Test plan

- [x] `uv run python -m pytest tests/ -v` — 1005 passed, 0 failures
- [x] `uv run mypy tvkit/` — exits 0
- [x] `uv run ruff check . && uv run ruff format .` — exits 0
- [x] `uv run python examples/ohlcv_dividend_adjusted.py` — menu-driven Rich output, shows adjustment difference
- [x] Backwards compatibility: omitting `adjustment` returns same data as v0.10.0 (`NASDAQ:AAPL` smoke test)

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/claude-code)