### PR TITLE
fix(chart): range-query series_completed fallback + inter-segment delay (v0.11.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,10 +172,14 @@ cython_debug/
 # Ruff
 .ruff_cache/
 
+# macOS metadata
+.DS_Store
+
 # Project-specific ignores (tvkit)
 # Development files (keep local only)
 debug/
 docs/plans/
+docs/issues/
 .claude/
 CLAUDE.md
 scripts/tvkit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] — 2026-04-25
+
+### Fixed
+
+- **Range mode: single-event `series_completed` fallback** (`tvkit/api/chart/ohlcv.py` →
+  `_fetch_single_range()`)  
+  When TradingView sends only one `series_completed` event for a range query — which occurs
+  under server-side throttling of repeated requests to continuous futures symbols such as
+  `CME_MINI:MNQ1!` — the old code discarded all bars accumulated during `create_series` and
+  waited for a second event that never arrived, eventually timing out and raising
+  `NoHistoricalDataError` with zero bars even though the correct data had already been received.  
+  The fix saves bars from the `create_series` response that fall within the requested date range
+  as a fallback before clearing. If `modify_series` subsequently returns nothing, the fallback
+  is used instead of raising. The normal two-event path is unchanged — the fallback only
+  activates when `modify_series` returns no bars.
+
+### Added
+
+- **`inter_segment_delay` parameter on `SegmentedFetchService`**
+  (`tvkit/api/chart/services/segmented_fetch_service.py`)  
+  New optional constructor parameter (default `0.0`) that inserts `asyncio.sleep()` between
+  consecutive segment fetches. Reduces server-side throttle pressure when fetching large date
+  ranges for continuous futures symbols. Skipped after the last segment.
+
+- **`segment_delay` parameter on `get_historical_ohlcv()`** (`tvkit/api/chart/ohlcv.py`)  
+  New keyword-only parameter (default `0.0`) forwarded to `SegmentedFetchService` as
+  `inter_segment_delay` when the requested date range triggers segmentation. Ignored in
+  count mode and for ranges that fit within a single request.  
+  Recommended value for continuous futures symbols: `segment_delay=2.0`.
+
+### Notes
+
+- All three changes are **100% backward-compatible** — every new parameter defaults to `0.0`,
+  replicating pre-fix behavior exactly. Existing call sites require no changes.
+- The root cause of bar count degradation across consecutive CME futures sessions is
+  TradingView backend throttling on rapid repeated range queries to continuous symbols (`!`
+  suffix). The `segment_delay` parameter and the fallback mechanism together mitigate the
+  impact, but server-side throttling cannot be eliminated by tvkit. See
+  `docs/issues/continuous-futures-intraday-range-degradation/solution.md` for full analysis
+  and recommended fetch patterns.
+
+---
+
 ## [0.11.0] — 2026-04-24
 
 ### Added

--- a/docs/concepts/capabilities.md
+++ b/docs/concepts/capabilities.md
@@ -8,7 +8,13 @@ tvkit can authenticate with a TradingView user account to unlock deeper historic
 
 ## TradingView Plans and Bar Limits
 
-TradingView offers five plan levels. Each plan determines the maximum number of bars accessible in a single historical fetch. See the [official TradingView pricing page](https://www.tradingview.com/pricing/) for the full feature comparison.
+TradingView offers five plan levels. Each plan determines `max_bars` — the total number of bars accessible, counted **backward from the latest bar in the series**. See the [official TradingView pricing page](https://www.tradingview.com/pricing/) for the full feature comparison.
+
+> **`max_bars` is a lookback window, not a per-request cap.** TradingView counts backward
+> from the latest bar in the series; any bar older than `max_bars` positions back is
+> inaccessible regardless of the fetch method. Range mode applies a date filter on top of
+> this window — dates before the oldest accessible bar return 0 bars with no error.
+> See [Limitations — The `max_bars` Window](../limitations.md#tradingview-historical-depth-limitation--the-max_bars-window).
 
 | TradingView plan | Internal plan slug | tvkit `tier` | `max_bars` |
 |------------------|--------------------|--------------|------------|

--- a/docs/guides/historical-data.md
+++ b/docs/guides/historical-data.md
@@ -110,34 +110,52 @@ asyncio.run(fetch_full_year_1min())
 
 ---
 
-## TradingView Historical Depth Limitation
+## The `max_bars` Lookback Window
 
-Automatic segmentation handles the per-request bar limit, but a separate server-side constraint controls how far back in time TradingView data is accessible: the **historical depth window**.
+Automatic segmentation handles the per-request bar limit, but a separate server-side policy controls how many bars are accessible at all: the **`max_bars` window**.
 
-TradingView exposes approximately ≈5,000 bars backward from the current time for free/basic accounts. Paid tiers provide deeper access. The table below shows approximate accessible depth by interval and account tier:
+> **Key concept:** TradingView serves at most `max_bars` bars counted **backward from the
+> latest bar in the series** — not from wall-clock current time.
 
-| Interval | Free / Basic | Essential / Plus | Premium | Expert | Ultimate |
-| -------- | ------------ | ---------------- | ------- | ------ | -------- |
-| 1 minute | ≈3.5 days | ≈17 days | ≈1 month | ≈3 months | ≈6 months |
-| 5 minutes | ≈17 days | ≈3 months | ≈6 months | ≈1 year | ≈2 years |
-| 15 minutes | ≈52 days | ≈9 months | ≈1.5 years | ≈3 years | ≈6 years |
-| 1 hour | ≈7 months | ≈3 years | ≈6 years | ≈12 years | ≈24 years |
-| 1 day | ≈27 years | Unlimited | Unlimited | Unlimited | Unlimited |
+**Range mode is a filter, not a deeper lookup.** The server first retrieves the last
+`max_bars` bars, then filters to your requested `start`/`end` range. If your date range
+falls entirely before the oldest accessible bar, you get 0 bars with no error raised.
 
-These are approximate, empirical values. TradingView does not publish official figures and limits may change.
+```text
+         ◄──────── max_bars window ──────────►
+         │                                   │
+[oldest accessible bar]          [latest bar in series]
+         │                                   │
+         │   ← range filter works here →     │
+         │
+ dates here → 0 bars, no error
+```
 
-**What happens when a segment falls outside the accessible window:**
+The same window applies to **segmented fetch**: segments beyond the window return empty
+results silently. The caller receives a valid but partial result.
 
-If a segment's date range is before the accessible window for your account tier, TradingView returns no bars for that segment. tvkit treats this as an empty result — it does not raise an error. This behavior mirrors TradingView's native chart behavior.
+**Accessible depth by interval and account tier** (assumes ~24 h/day continuous trading;
+instruments with trading gaps span proportionally more calendar days):
 
-**This limit is distinct from `MAX_BARS_REQUEST`:**
+| Interval   | Free / Basic | Essential / Plus | Premium   | Ultimate  |
+| ---------- | ------------ | ---------------- | --------- | --------- |
+| 1 minute   | ≈3.5 days    | ≈7 days          | ≈14 days  | ≈28 days  |
+| 5 minutes  | ≈17 days     | ≈35 days         | ≈70 days  | ≈140 days |
+| 15 minutes | ≈52 days     | ≈104 days        | ≈208 days | ≈416 days |
+| 1 hour     | ≈7 months    | ≈14 months       | ≈28 months| ≈56 months|
+| 1 day      | ≈13 years    | Unlimited        | Unlimited | Unlimited |
+
+These figures are derived from `max_bars` counts. TradingView does not publish official
+figures; limits may change.
+
+**`MAX_BARS_REQUEST` vs `max_bars`:**
 
 | Concept | What it controls |
 | ------- | ---------------- |
-| `MAX_BARS_REQUEST` | Protocol limit on bars per single fetch request |
-| Historical depth | Server-side rolling window of accessible history per account tier |
+| `MAX_BARS_REQUEST` | Protocol limit — max bars in a single WebSocket request |
+| `max_bars` (lookback window) | Account policy — total bars accessible, counted from the latest bar |
 
-See [Limitations](../limitations.md) for the full depth table and further details.
+See [Limitations — The `max_bars` Window](../limitations.md#tradingview-historical-depth-limitation--the-max_bars-window) for full details.
 
 ---
 
@@ -145,9 +163,9 @@ See [Limitations](../limitations.md) for the full depth table and further detail
 
 If your result contains fewer bars than the date range would suggest, one of these reasons applies:
 
-- **Historical depth window** — your requested `start` date is before the accessible history for your TradingView account tier. Segments outside the window return empty results. Upgrade your account or shorten the date range.
+- **Outside the `max_bars` window** — your requested `start` date is before the oldest bar accessible for your account tier. The window is measured from the latest bar in the series, not from wall-clock time. Segments outside the window return 0 bars silently. Upgrade your account or shorten the date range.
 - **Market gaps** — weekends, public holidays, and illiquid periods contain no bars. Segments covering these periods are skipped. This is expected behavior, not a bug.
-- **Bar count mode** — `bars_count` mode always returns at most N bars counting backward from the present. Use `start`/`end` range mode to target a specific historical window.
+- **Bar count mode** — `bars_count` mode always returns at most N bars counting backward from the latest bar in the series. Use `start`/`end` range mode to target a specific historical window within the `max_bars` limit.
 
 See [Limitations → TradingView Historical Depth Limitation](../limitations.md) for account-tier depth figures.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ async with OHLCV() as client:
 
 - [Connection Service](internals/connection-service.md)
 - [Message Service](internals/message-service.md)
+- [Segmented Fetch](internals/segmented-fetch.md) — automatic range splitting, `max_bars` window, `inter_segment_delay`
 
 ---
 

--- a/docs/internals/segmented-fetch.md
+++ b/docs/internals/segmented-fetch.md
@@ -13,6 +13,25 @@ When a caller requests a date range that would produce more than `MAX_BARS_REQUE
 
 ---
 
+## The `max_bars` Window — What Segmentation Cannot Override
+
+Segmentation splits a large date range into smaller WebSocket requests, each capped at `MAX_BARS_REQUEST` bars. This solves the protocol-level request cap. It does **not** extend the server-side history window.
+
+TradingView serves at most `max_bars` bars **counted backward from the latest bar in the series**. This is the account-tier policy limit:
+
+| Account tier     | `max_bars` |
+|------------------|------------|
+| Free / anonymous | 5,000      |
+| Essential / Plus | 10,000     |
+| Premium          | 20,000     |
+| Ultimate         | 40,000     |
+
+Segments that request bars older than the `max_bars` window receive `NoHistoricalDataError` from TradingView. `fetch_all()` treats these as empty results — no error propagates to the caller. See [Empty Segment Handling](#empty-segment-handling).
+
+**Practical implication:** if the full requested date range spans more bars than `max_bars`, only the segments closest to the latest bar will return data. Segments beyond the window silently return empty. The caller receives a partial (but valid) result with no indication that history was truncated.
+
+---
+
 ## Dispatch Decision
 
 The dispatch is decided in `OHLCV.get_historical_ohlcv()` by `_needs_segmentation(start, end, interval)`:
@@ -63,6 +82,33 @@ Key invariants:
 | No gap | `segs[i+1].start == segs[i].end + interval_seconds` |
 | Full coverage | `segs[0].start == start` and `segs[-1].end == end` |
 | Last clamped | The last segment's end is always exactly `end`, never beyond |
+
+---
+
+## Inter-Segment Delay (v0.11.1+)
+
+`SegmentedFetchService` accepts an optional `inter_segment_delay: float` parameter
+(default `0.0`, unit: seconds). When positive, `fetch_all()` calls
+`asyncio.sleep(inter_segment_delay)` after each segment fetch except the last.
+
+```python
+SegmentedFetchService(
+    client=self,
+    max_bars_per_segment=MAX_BARS_REQUEST,
+    inter_segment_delay=2.0,   # sleep 2s between segments
+)
+```
+
+**Why this matters for continuous futures:** TradingView throttles repeated WebSocket
+requests to the same continuous symbol (`MNQ1!`, `ES1!`, etc.). Without a delay, rapid
+successive segments trigger the throttle, causing later segments to return fewer bars or
+fall back to the single-event `series_completed` recovery path. A 2–3 second delay
+between segments substantially reduces throttle pressure at the cost of proportionally
+longer total fetch time.
+
+The delay is exposed to callers via the `segment_delay` keyword argument on
+`get_historical_ohlcv()`. It is ignored in count mode and for ranges that fit in a
+single segment.
 
 ---
 
@@ -126,7 +172,12 @@ For a 350-segment fetch, this produces ~36 INFO lines (first, last, and every 35
 
 ### Possible Future Enhancement (Heuristic Warning)
 
-A heuristic warning could be emitted when the segment count and interval suggest the request is likely to fall outside the accessible TradingView history window for free-tier accounts (e.g., `total_segments * interval_seconds > 3.5 * 86400` for 1-minute bars). This advisory log would help users diagnose unexpectedly short result sets without requiring access to TradingView account tier information. This enhancement is deferred — it is not implemented in v0.5.0.
+A heuristic warning could be emitted when the segment count and interval suggest the
+request is likely to fall outside the accessible `max_bars` window for the account tier
+(e.g., estimated bars across all segments exceed `account.max_bars`). This advisory log
+would help users diagnose unexpectedly short result sets — currently the caller receives
+a partial result with no indication that history was truncated by the window. This
+enhancement is deferred.
 
 ---
 
@@ -152,9 +203,10 @@ get_historical_ohlcv(symbol, interval, start, end)
         │
         ├─ for each segment [1..N]:
         │     ├─ _fetch_single_range(symbol, interval, seg.start, seg.end)
-        │     │     ├─ NoHistoricalDataError → bars = []  (skip)
+        │     │     ├─ NoHistoricalDataError → bars = []  (skip, outside max_bars window)
         │     │     └─ Exception → SegmentedFetchError    (abort)
-        │     └─ all_bars.extend(bars)
+        │     ├─ all_bars.extend(bars)
+        │     └─ asyncio.sleep(inter_segment_delay)  ← if > 0 and not last segment
         │
         └─ _deduplicate_and_sort(all_bars)
               └─ returns list[OHLCVBar]

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -17,34 +17,76 @@ print(MAX_BARS_REQUEST)  # inspect the current limit
 
 ---
 
-## TradingView Historical Depth Limitation
+## TradingView Historical Depth Limitation — The `max_bars` Window
 
-Separate from the per-request bar limit, TradingView imposes a server-side rolling window that controls how far back in time data is accessible. This window is not the number of bars per request — it is the maximum age of accessible data for your account tier.
+Separate from the per-request bar limit, TradingView imposes a server-side rolling window
+that controls how many bars are accessible per account tier. Understanding this window
+correctly is essential for both count mode and range mode.
 
-Free/basic accounts can access approximately ≈5,000 bars backward from the current time. Paid tiers allow deeper history. The table below shows approximate accessible depth by interval and account tier:
+### What `max_bars` actually means
 
-| Interval | Basic (free) | Essential / Plus | Premium | Ultimate |
-| -------- | ------------ | ---------------- | ------- | -------- |
-| 1 minute | ≈3.5 days | ≈17 days | ≈1 month | ≈6 months |
-| 5 minutes | ≈17 days | ≈3 months | ≈6 months | ≈2 years |
-| 15 minutes | ≈52 days | ≈9 months | ≈1.5 years | ≈6 years |
-| 1 hour | ≈7 months | ≈3 years | ≈6 years | ≈24 years |
-| 1 day | ≈27 years | Unlimited | Unlimited | Unlimited |
+> TradingView serves at most `max_bars` bars **counted backward from the latest bar in the
+> series** — not from wall-clock current time.
 
-These are approximate, empirical values. TradingView does not publish official figures and limits may change.
+For most liquid markets (equities, crypto, forex) the latest bar is a few minutes behind
+real time, so the distinction rarely matters. It matters significantly for:
 
-**Effect on segmented fetching:**
+- **Futures contracts** with daily maintenance breaks or weekend closures — the window spans
+  more calendar days than a 24×7 instrument with the same bar count
+- **Specific expiry contracts near or past expiry** — the latest bar may be days or weeks old
+- **Thinly traded instruments** — gaps in the series move the oldest accessible bar closer
+  to the latest bar's timestamp
 
-When `get_historical_ohlcv()` automatically segments a large date range, segments that fall before the accessible window for your account tier return no bars. tvkit treats these as empty results — no error is raised. This behavior mirrors TradingView's native chart behavior.
+### Range mode is a filter, not a deeper lookup
+
+A common misconception is that range mode (`start=..., end=...`) provides access to older
+data than count mode. It does not. Both modes are bounded by the same `max_bars` window.
+
+```text
+         ◄──────── max_bars window ──────────►
+         │                                   │
+[oldest accessible bar]          [latest bar in series]
+         │                                   │
+         │  ← range mode filter works here → │
+         │
+ dates here → 0 bars returned, no error raised
+```
+
+The server first retrieves the last `max_bars` bars, then applies the date filter.
+If the requested date range falls entirely before the oldest accessible bar, 0 bars are
+returned — no `NoHistoricalDataError` is raised, because the series itself is valid.
+
+This also applies to **segmented fetch**: `get_historical_ohlcv()` automatically splits
+large date ranges into smaller requests, but each segment is still bounded by the same
+`max_bars` window. Segments older than the window return empty results silently.
+
+### Accessible depth by interval and account tier
+
+The table below shows approximate calendar-equivalent lookback for each tier, assuming
+continuous 24-hour trading. For instruments with trading gaps (e.g. CME futures with a
+1-hour daily maintenance break and weekend closure), the equivalent calendar span is
+proportionally longer.
+
+| Interval   | Basic (free)  | Essential / Plus | Premium    | Ultimate    |
+| ---------- | ------------- | ---------------- | ---------- | ----------- |
+| 1 minute   | ≈3.5 days     | ≈7 days          | ≈14 days   | ≈28 days    |
+| 5 minutes  | ≈17 days      | ≈35 days         | ≈70 days   | ≈140 days   |
+| 15 minutes | ≈52 days      | ≈104 days        | ≈208 days  | ≈416 days   |
+| 1 hour     | ≈7 months     | ≈14 months       | ≈28 months | ≈56 months  |
+| 1 day      | ≈27 years     | Unlimited        | Unlimited  | Unlimited   |
+
+These are approximate, empirical values based on `max_bars` counts. TradingView does not
+publish official figures and limits may change.
 
 **Distinction from `MAX_BARS_REQUEST`:**
 
 | Concept | What it controls |
 | ------- | ---------------- |
-| `MAX_BARS_REQUEST` | Protocol limit — maximum bars in a single fetch request |
-| Historical depth | Server-side policy — maximum age of accessible data per account tier |
+| `MAX_BARS_REQUEST` | Protocol limit — maximum bars returned in a single WebSocket request |
+| `max_bars` (historical depth) | Account policy — total bars accessible, counted from the latest bar |
 
-**Resolution:** To access older data, upgrade your TradingView account tier or switch to a wider interval (e.g., `"1H"` instead of `"1"`).
+**Resolution:** To access older data, upgrade your TradingView account tier or switch to a
+wider interval (e.g., `"1H"` instead of `"1"`).
 
 ## Rate Limiting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvkit"
-version = "0.11.0"
+version = "0.11.1"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_futures_range_degradation.py
+++ b/tests/test_futures_range_degradation.py
@@ -1,0 +1,717 @@
+"""
+Tests for the continuous futures intraday range degradation bug fix (v0.11.1).
+
+Covers three independent fixes:
+
+  Fix 1 — pre_modify_bars_in_range fallback in _fetch_single_range():
+    When TradingView sends only one series_completed event (throttled server or
+    single-event protocol variant), bars from the create_series response that fall
+    within the requested date range are used as a fallback instead of raising
+    NoHistoricalDataError.
+
+  Fix 2 — inter_segment_delay in SegmentedFetchService:
+    asyncio.sleep() is injected between consecutive segment fetches when
+    inter_segment_delay > 0.0. The sleep is skipped after the last segment.
+
+  Fix 3 — segment_delay public parameter on get_historical_ohlcv():
+    The new keyword-only segment_delay parameter is forwarded to
+    SegmentedFetchService when the range triggers segmentation.
+    Ignored in count mode and for single-segment ranges.
+
+No live WebSocket connections — all external I/O is mocked.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from tvkit.api.chart.exceptions import NoHistoricalDataError
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.api.chart.ohlcv import OHLCV, _StreamingSession
+from tvkit.api.chart.services.segmented_fetch_service import SegmentedFetchService
+from tvkit.api.chart.utils import MAX_BARS_REQUEST
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+SYMBOL: str = "CME_MINI:MNQ1!"
+
+# Unix timestamp for 2024-01-01 00:00:00 UTC — bars stamped here are inside
+# the 2024-01-01 → 2024-12-31 test window used throughout this module.
+_TS_JAN_2024: float = 1_704_067_200.0
+
+# A timestamp clearly OUTSIDE the 2024 test window (year 2023).
+_TS_OUTSIDE_RANGE: float = 1_672_531_200.0  # 2023-01-01 00:00 UTC
+
+# ---------------------------------------------------------------------------
+# Wire messages
+# ---------------------------------------------------------------------------
+
+SERIES_COMPLETED_MSG: dict[str, Any] = {
+    "m": "series_completed",
+    "p": ["cs_xxx", "sds_1", "sds_sym_1", "ok"],
+}
+SERIES_LOADING_MSG: dict[str, Any] = {
+    "m": "series_loading",
+    "p": ["cs_xxx", "sds_1"],
+}
+
+
+def make_timescale_update(
+    bars_count: int,
+    base_ts: float = _TS_JAN_2024,
+) -> dict[str, Any]:
+    """Build a fake timescale_update with ``bars_count`` bars starting at ``base_ts``."""
+    series: list[dict[str, Any]] = [
+        {"i": i, "v": [base_ts + i * 60, 100.0, 105.0, 95.0, 102.0, float(i + 1)]}
+        for i in range(bars_count)
+    ]
+    return {"m": "timescale_update", "p": ["cs_xxx", {"sds_1": {"s": series}}]}
+
+
+async def fake_stream(
+    messages: list[dict[str, Any]],
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Yield a pre-defined sequence of messages then stop."""
+    for msg in messages:
+        yield msg
+
+
+def _make_range_client(messages: list[dict[str, Any]]) -> OHLCV:
+    """Return an OHLCV client wired for range-mode tests with mocked services."""
+    client = OHLCV()
+    client._prepare_chart_session = AsyncMock()  # type: ignore[method-assign]
+    client._session = _StreamingSession(  # type: ignore[assignment]
+        symbol=SYMBOL,
+        interval="1",
+        bars_count=MAX_BARS_REQUEST,
+        quote_session="qs_test",
+        chart_session="cs_test",
+    )
+    client.connection_service = MagicMock()
+    client.connection_service.get_data_stream = lambda: fake_stream(messages)
+    client.connection_service.close = AsyncMock()
+    client.message_service = MagicMock()  # type: ignore[assignment]
+    return client
+
+
+def _make_patches() -> dict[str, Any]:
+    return {
+        "validate_symbols": AsyncMock(return_value=True),
+        "normalize_symbol": MagicMock(return_value=SYMBOL),
+        "validate_interval": MagicMock(),
+    }
+
+
+def make_bar(ts: float, volume: float = 100.0) -> OHLCVBar:
+    return OHLCVBar(timestamp=ts, open=1.0, high=2.0, low=0.5, close=1.5, volume=volume)
+
+
+# ===========================================================================
+# Fix 1 — pre_modify_bars_in_range fallback
+# ===========================================================================
+
+
+class TestPreModifyFallback:
+    """
+    Fix 1: fallback for single-event series_completed in _fetch_single_range().
+
+    When TradingView sends only the first series_completed (throttle, continuous
+    futures edge case, or single-event protocol variant), bars from the
+    create_series response that fall within the requested date range are saved as
+    a fallback. If modify_series returns nothing, those bars are returned instead
+    of raising NoHistoricalDataError.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_event_activates_fallback(self) -> None:
+        """Single series_completed with in-range bars → fallback returns those bars.
+
+        Simulates TradingView throttling on CME_MINI:MNQ1!: bars arrive before
+        the first (and only) series_completed. The stream then ends with no second
+        event. Expected: fallback activates and returns the in-range bars.
+        """
+        messages: list[dict[str, Any]] = [
+            SERIES_LOADING_MSG,
+            make_timescale_update(bars_count=5, base_ts=_TS_JAN_2024),
+            SERIES_COMPLETED_MSG,  # Only one event — throttled server
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_single_event_no_in_range_bars_raises(self) -> None:
+        """Single series_completed with NO in-range bars → NoHistoricalDataError.
+
+        The create_series response contains only bars outside the requested range.
+        Fallback cannot activate, so NoHistoricalDataError is raised.
+
+        Uses a same-day range (start == end) so _needs_segmentation() returns False
+        and the single-range path in _fetch_single_range() is exercised directly.
+        """
+        messages: list[dict[str, Any]] = [
+            make_timescale_update(bars_count=5, base_ts=_TS_OUTSIDE_RANGE),
+            SERIES_COMPLETED_MSG,
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            with pytest.raises(NoHistoricalDataError):
+                # Same-day range → 0 estimated bars → no segmentation
+                await client.get_historical_ohlcv(SYMBOL, "1", start="2024-01-01", end="2024-01-01")
+
+    @pytest.mark.asyncio
+    async def test_single_event_fallback_filters_out_of_range_bars(self) -> None:
+        """Fallback only returns bars that fall within the requested date range.
+
+        The create_series response contains both in-range and out-of-range bars.
+        Only the in-range subset must be returned via the fallback.
+        """
+        in_range_ts = _TS_JAN_2024
+        out_of_range_ts = _TS_OUTSIDE_RANGE
+        series: list[dict[str, Any]] = [
+            {"i": i, "v": [out_of_range_ts + i * 60, 1.0, 2.0, 0.5, 1.5, 1.0]} for i in range(3)
+        ] + [{"i": i + 3, "v": [in_range_ts + i * 60, 1.0, 2.0, 0.5, 1.5, 1.0]} for i in range(4)]
+        msg: dict[str, Any] = {"m": "timescale_update", "p": ["cs_xxx", {"sds_1": {"s": series}}]}
+        messages = [msg, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 4
+        assert all(b.timestamp >= _TS_JAN_2024 for b in result)
+
+    @pytest.mark.asyncio
+    async def test_two_events_normal_path_not_affected(self) -> None:
+        """Two series_completed events — normal path: fallback is NOT activated.
+
+        The second series_completed carries the modify_series response with bars.
+        The first-event create_series bars are discarded as usual.
+        """
+        create_series_bars = make_timescale_update(bars_count=3, base_ts=_TS_JAN_2024)
+        modify_series_bars = make_timescale_update(bars_count=7, base_ts=_TS_JAN_2024 + 10_000)
+        messages: list[dict[str, Any]] = [
+            create_series_bars,
+            SERIES_COMPLETED_MSG,  # First: create_series — cleared
+            modify_series_bars,
+            SERIES_COMPLETED_MSG,  # Second: modify_series — break
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        # Only the 7 modify_series bars, not the 3 create_series bars
+        assert len(result) == 7
+        assert all(b.timestamp >= _TS_JAN_2024 + 10_000 for b in result)
+
+    @pytest.mark.asyncio
+    async def test_two_events_second_empty_activates_fallback(self) -> None:
+        """Two events but second event returns no bars — fallback activates.
+
+        The modify_series response delivers zero bars (server throttle at its worst).
+        The saved create_series bars are returned via the fallback.
+        """
+        create_series_bars = make_timescale_update(bars_count=5, base_ts=_TS_JAN_2024)
+        messages: list[dict[str, Any]] = [
+            create_series_bars,
+            SERIES_COMPLETED_MSG,  # First: create_series — cleared, fallback saved
+            SERIES_COMPLETED_MSG,  # Second: modify_series — no bars, break
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_fallback_bars_sorted_ascending(self) -> None:
+        """Fallback bars are sorted in ascending timestamp order."""
+        base = _TS_JAN_2024
+        series: list[dict[str, Any]] = [
+            {"i": i, "v": [base + (4 - i) * 60, 1.0, 2.0, 0.5, 1.5, 1.0]}  # descending ts
+            for i in range(5)
+        ]
+        msg: dict[str, Any] = {"m": "timescale_update", "p": ["cs_xxx", {"sds_1": {"s": series}}]}
+        messages = [msg, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        timestamps = [b.timestamp for b in result]
+        assert timestamps == sorted(timestamps)
+
+    @pytest.mark.asyncio
+    async def test_fallback_log_message_emitted(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A structured INFO log is emitted when the fallback activates."""
+        messages: list[dict[str, Any]] = [
+            make_timescale_update(bars_count=3, base_ts=_TS_JAN_2024),
+            SERIES_COMPLETED_MSG,
+        ]
+        client = _make_range_client(messages)
+
+        with (
+            patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()),
+            caplog.at_level(logging.INFO, logger="tvkit.api.chart.ohlcv"),
+        ):
+            await client.get_historical_ohlcv(SYMBOL, "1", start="2024-01-01", end="2024-12-31")
+
+        fallback_records = [r for r in caplog.records if "falling back" in r.message]
+        assert len(fallback_records) == 1
+        assert "3" in fallback_records[0].message
+
+    @pytest.mark.asyncio
+    async def test_fallback_not_triggered_when_modify_series_has_bars(self) -> None:
+        """The fallback bar count is irrelevant when modify_series provides bars.
+
+        Even if the create_series response had more in-range bars than the
+        modify_series response, the latter always wins (normal path).
+        """
+        create_series_bars = make_timescale_update(bars_count=10, base_ts=_TS_JAN_2024)
+        modify_series_bars = make_timescale_update(bars_count=2, base_ts=_TS_JAN_2024 + 50_000)
+        messages: list[dict[str, Any]] = [
+            create_series_bars,
+            SERIES_COMPLETED_MSG,
+            modify_series_bars,
+            SERIES_COMPLETED_MSG,
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 2
+        assert all(b.timestamp >= _TS_JAN_2024 + 50_000 for b in result)
+
+    @pytest.mark.asyncio
+    async def test_empty_create_series_single_event_raises(self) -> None:
+        """No bars before the only series_completed → NoHistoricalDataError.
+
+        Uses a same-day range (start == end) so _needs_segmentation() returns False
+        and the single-range path in _fetch_single_range() is exercised directly.
+        """
+        messages: list[dict[str, Any]] = [
+            SERIES_LOADING_MSG,
+            SERIES_COMPLETED_MSG,
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            with pytest.raises(NoHistoricalDataError):
+                # Same-day range → 0 estimated bars → no segmentation
+                await client.get_historical_ohlcv(SYMBOL, "1", start="2024-01-01", end="2024-01-01")
+
+    @pytest.mark.asyncio
+    async def test_intraday_range_boundaries_respected(self) -> None:
+        """Fallback filter uses exact datetime boundaries, not date-only expansion.
+
+        When start/end are UTC datetimes with an explicit time component,
+        end_of_day_timestamp() returns the exact timestamp (no +86399 expansion).
+        Bars outside the intraday window must be excluded from the fallback.
+        """
+        session_start = datetime(2024, 1, 1, 22, 0, 0, tzinfo=UTC)
+        session_end = datetime(2024, 1, 2, 21, 0, 0, tzinfo=UTC)
+
+        ts_in = session_start.timestamp() + 30 * 60  # 22:30 — inside window
+        ts_before = session_start.timestamp() - 3600  # 21:00 — before window
+        ts_after = session_end.timestamp() + 3600  # 22:00 next day — after window
+
+        series: list[dict[str, Any]] = [
+            {"i": 0, "v": [ts_before, 1.0, 2.0, 0.5, 1.5, 1.0]},
+            {"i": 1, "v": [ts_in, 1.0, 2.0, 0.5, 1.5, 1.0]},
+            {"i": 2, "v": [ts_after, 1.0, 2.0, 0.5, 1.5, 1.0]},
+        ]
+        msg: dict[str, Any] = {"m": "timescale_update", "p": ["cs_xxx", {"sds_1": {"s": series}}]}
+        messages: list[dict[str, Any]] = [msg, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start=session_start, end=session_end
+            )
+
+        assert len(result) == 1
+        assert result[0].timestamp == ts_in
+
+    @pytest.mark.asyncio
+    async def test_multiple_timescale_updates_before_single_event(self) -> None:
+        """Bars spread across multiple timescale_update messages are all captured in fallback."""
+        messages: list[dict[str, Any]] = [
+            make_timescale_update(bars_count=3, base_ts=_TS_JAN_2024),
+            make_timescale_update(bars_count=4, base_ts=_TS_JAN_2024 + 1000),
+            SERIES_COMPLETED_MSG,  # Single event — all 7 bars saved as fallback
+        ]
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 7
+
+
+# ===========================================================================
+# Fix 2 — inter_segment_delay in SegmentedFetchService
+# ===========================================================================
+
+
+class TestInterSegmentDelay:
+    """
+    Fix 2: asyncio.sleep() is injected between consecutive segment fetches
+    when inter_segment_delay > 0.0. Skipped after the last segment.
+    """
+
+    @staticmethod
+    def _service_with_delay(
+        delay: float, n_segments: int
+    ) -> tuple[SegmentedFetchService, AsyncMock]:
+        """Return a service + mock where every segment returns 1 bar."""
+        mock_client = AsyncMock(spec=OHLCV)
+        mock_client._auth_manager = None
+        mock_client._fetch_single_range = AsyncMock(
+            side_effect=[[make_bar(float(i * 3600))] for i in range(n_segments)]
+        )
+        service = SegmentedFetchService(
+            client=mock_client,
+            max_bars_per_segment=1,
+            inter_segment_delay=delay,
+        )
+        return service, mock_client
+
+    @pytest.mark.asyncio
+    async def test_delay_called_between_segments_not_after_last(self) -> None:
+        """asyncio.sleep() is called N-1 times for N segments (skipped after last)."""
+        n = 3
+        service, _ = self._service_with_delay(delay=2.0, n_segments=n)
+
+        with patch("tvkit.api.chart.services.segmented_fetch_service.asyncio.sleep") as mock_sleep:
+            await service.fetch_all(
+                SYMBOL,
+                "1H",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=n - 1),
+            )
+
+        assert mock_sleep.call_count == n - 1
+        mock_sleep.assert_called_with(2.0)
+
+    @pytest.mark.asyncio
+    async def test_no_sleep_when_delay_is_zero(self) -> None:
+        """asyncio.sleep() is never called when inter_segment_delay=0.0."""
+        service, _ = self._service_with_delay(delay=0.0, n_segments=3)
+
+        with patch("tvkit.api.chart.services.segmented_fetch_service.asyncio.sleep") as mock_sleep:
+            await service.fetch_all(
+                SYMBOL,
+                "1H",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=2),
+            )
+
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_segment_no_sleep(self) -> None:
+        """A single-segment fetch never triggers a sleep."""
+        mock_client = AsyncMock(spec=OHLCV)
+        mock_client._auth_manager = None
+        mock_client._fetch_single_range = AsyncMock(return_value=[make_bar(1000.0)])
+        service = SegmentedFetchService(
+            client=mock_client,
+            max_bars_per_segment=MAX_BARS_REQUEST,
+            inter_segment_delay=5.0,
+        )
+
+        with patch("tvkit.api.chart.services.segmented_fetch_service.asyncio.sleep") as mock_sleep:
+            await service.fetch_all(
+                SYMBOL,
+                "1H",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=1),
+            )
+
+        mock_sleep.assert_not_called()
+
+    def test_default_delay_is_zero(self) -> None:
+        """SegmentedFetchService constructor default inter_segment_delay is 0.0."""
+        mock_client = MagicMock(spec=OHLCV)
+        service = SegmentedFetchService(client=mock_client)
+        assert service._inter_segment_delay == 0.0
+
+    def test_constructor_stores_delay(self) -> None:
+        """The delay value provided at construction is stored correctly."""
+        mock_client = MagicMock(spec=OHLCV)
+        service = SegmentedFetchService(client=mock_client, inter_segment_delay=3.5)
+        assert service._inter_segment_delay == 3.5
+
+    @pytest.mark.asyncio
+    async def test_delay_value_passed_to_each_sleep_call(self) -> None:
+        """The exact delay value is forwarded to every asyncio.sleep() call."""
+        n = 4
+        delay = 1.5
+        service, _ = self._service_with_delay(delay=delay, n_segments=n)
+
+        with patch("tvkit.api.chart.services.segmented_fetch_service.asyncio.sleep") as mock_sleep:
+            await service.fetch_all(
+                SYMBOL,
+                "1H",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=n - 1),
+            )
+
+        expected_calls = [call(delay)] * (n - 1)
+        mock_sleep.assert_has_calls(expected_calls, any_order=False)
+
+    @pytest.mark.asyncio
+    async def test_delay_exactly_n_minus_one_calls(self) -> None:
+        """For N segments, exactly N-1 sleep calls — confirmed for N=2, 3, 4."""
+        for n in (2, 3, 4):
+            service, _ = self._service_with_delay(delay=0.5, n_segments=n)
+            with patch(
+                "tvkit.api.chart.services.segmented_fetch_service.asyncio.sleep"
+            ) as mock_sleep:
+                await service.fetch_all(
+                    SYMBOL,
+                    "1H",
+                    start=datetime(2024, 1, 1, tzinfo=UTC),
+                    end=datetime(2024, 1, 1, tzinfo=UTC) + timedelta(hours=n - 1),
+                )
+            assert mock_sleep.call_count == n - 1, f"Expected {n - 1} calls for {n} segments"
+
+
+# ===========================================================================
+# Fix 3 — segment_delay public parameter on get_historical_ohlcv()
+# ===========================================================================
+
+
+class TestSegmentDelayParameter:
+    """
+    Fix 3: segment_delay is forwarded to SegmentedFetchService when the
+    requested date range triggers segmentation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_segment_delay_forwarded_to_service(self) -> None:
+        """segment_delay is passed as inter_segment_delay to SegmentedFetchService."""
+        client = OHLCV()
+        mock_service = AsyncMock(spec=SegmentedFetchService)
+        mock_service.fetch_all = AsyncMock(return_value=[make_bar(float(_TS_JAN_2024))])
+
+        start_dt = datetime(2024, 1, 1, tzinfo=UTC)
+        end_dt = start_dt + timedelta(days=10)  # >5000 bars at 1-min → triggers segmentation
+
+        with (
+            patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()),
+            patch(
+                "tvkit.api.chart.ohlcv.SegmentedFetchService",
+                return_value=mock_service,
+            ) as mock_cls,
+        ):
+            await client.get_historical_ohlcv(
+                SYMBOL, "1", start=start_dt, end=end_dt, segment_delay=2.5
+            )
+
+        mock_cls.assert_called_once()
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["inter_segment_delay"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_segment_delay_default_is_zero(self) -> None:
+        """Omitting segment_delay defaults to 0.0 forwarded to SegmentedFetchService."""
+        client = OHLCV()
+        mock_service = AsyncMock(spec=SegmentedFetchService)
+        mock_service.fetch_all = AsyncMock(return_value=[make_bar(float(_TS_JAN_2024))])
+
+        start_dt = datetime(2024, 1, 1, tzinfo=UTC)
+        end_dt = start_dt + timedelta(days=10)
+
+        with (
+            patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()),
+            patch(
+                "tvkit.api.chart.ohlcv.SegmentedFetchService",
+                return_value=mock_service,
+            ) as mock_cls,
+        ):
+            await client.get_historical_ohlcv(SYMBOL, "1", start=start_dt, end=end_dt)
+
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["inter_segment_delay"] == 0.0
+
+    def test_get_historical_ohlcv_signature_has_segment_delay(self) -> None:
+        """get_historical_ohlcv() signature includes segment_delay with default 0.0."""
+        import inspect
+
+        sig = inspect.signature(OHLCV.get_historical_ohlcv)
+        param = sig.parameters.get("segment_delay")
+        assert param is not None, "segment_delay parameter missing from get_historical_ohlcv"
+        assert param.default == 0.0
+
+    @pytest.mark.asyncio
+    async def test_segment_delay_ignored_in_count_mode(self) -> None:
+        """segment_delay has no effect in count mode (SegmentedFetchService not instantiated)."""
+        messages: list[dict[str, Any]] = [
+            make_timescale_update(bars_count=5),
+            SERIES_COMPLETED_MSG,
+        ]
+        client = OHLCV()
+        client._prepare_chart_session = AsyncMock()  # type: ignore[method-assign]
+        client._session = _StreamingSession(  # type: ignore[assignment]
+            symbol=SYMBOL,
+            interval="1",
+            bars_count=5,
+            quote_session="qs_test",
+            chart_session="cs_test",
+        )
+        client.connection_service = MagicMock()
+        client.connection_service.get_data_stream = lambda: fake_stream(messages)
+        client.connection_service.close = AsyncMock()
+
+        with (
+            patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()),
+            patch("tvkit.api.chart.ohlcv.SegmentedFetchService") as mock_cls,
+        ):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", bars_count=5, segment_delay=99.0
+            )
+
+        mock_cls.assert_not_called()
+        assert len(result) == 5
+
+    @pytest.mark.asyncio
+    async def test_segment_delay_ignored_for_small_range(self) -> None:
+        """segment_delay is ignored when the range fits within a single request."""
+        start_dt = datetime(2024, 1, 1, tzinfo=UTC)
+        end_dt = start_dt + timedelta(minutes=10)  # 10 bars — no segmentation
+
+        create_bars = make_timescale_update(bars_count=2, base_ts=_TS_JAN_2024)
+        modify_bars = make_timescale_update(bars_count=3, base_ts=_TS_JAN_2024 + 200)
+        messages = [create_bars, SERIES_COMPLETED_MSG, modify_bars, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with (
+            patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()),
+            patch("tvkit.api.chart.ohlcv.SegmentedFetchService") as mock_cls,
+        ):
+            await client.get_historical_ohlcv(
+                SYMBOL, "1", start=start_dt, end=end_dt, segment_delay=5.0
+            )
+
+        mock_cls.assert_not_called()
+
+
+# ===========================================================================
+# Regression: backward compatibility
+# ===========================================================================
+
+
+class TestBackwardCompatibility:
+    """
+    All three fixes must be 100% backward-compatible — existing call sites
+    must continue to work without modification.
+    """
+
+    def test_segmented_fetch_service_zero_arg_construction(self) -> None:
+        """SegmentedFetchService(client) — zero extra args still works."""
+        mock_client = MagicMock(spec=OHLCV)
+        service = SegmentedFetchService(client=mock_client)
+        assert service._inter_segment_delay == 0.0
+
+    def test_segmented_fetch_service_positional_max_bars_unchanged(self) -> None:
+        """SegmentedFetchService(client, 5000) — second positional arg unchanged."""
+        mock_client = MagicMock(spec=OHLCV)
+        service = SegmentedFetchService(client=mock_client, max_bars_per_segment=5000)
+        assert service._max_bars_per_segment == 5000
+        assert service._inter_segment_delay == 0.0
+
+    @pytest.mark.asyncio
+    async def test_count_mode_existing_call_site_unchanged(self) -> None:
+        """get_historical_ohlcv('X', '1D', bars_count=500) — existing signature works."""
+        messages: list[dict[str, Any]] = [
+            make_timescale_update(bars_count=10),
+            SERIES_COMPLETED_MSG,
+        ]
+        client = OHLCV()
+        client._prepare_chart_session = AsyncMock()  # type: ignore[method-assign]
+        client._session = _StreamingSession(  # type: ignore[assignment]
+            symbol="NASDAQ:AAPL",
+            interval="1D",
+            bars_count=500,
+            quote_session="qs_test",
+            chart_session="cs_test",
+        )
+        client.connection_service = MagicMock()
+        client.connection_service.get_data_stream = lambda: fake_stream(messages)
+        client.connection_service.close = AsyncMock()
+
+        with patch.multiple(
+            "tvkit.api.chart.ohlcv",
+            validate_symbols=AsyncMock(return_value=True),
+            normalize_symbol=MagicMock(return_value="NASDAQ:AAPL"),
+            validate_interval=MagicMock(),
+        ):
+            result = await client.get_historical_ohlcv("NASDAQ:AAPL", "1D", bars_count=500)
+
+        assert len(result) == 10
+
+    @pytest.mark.asyncio
+    async def test_range_mode_two_event_path_unchanged(self) -> None:
+        """get_historical_ohlcv(start=..., end=...) — two-event path returns correct bars."""
+        create_bars = make_timescale_update(bars_count=3, base_ts=_TS_JAN_2024)
+        modify_bars = make_timescale_update(bars_count=8, base_ts=_TS_JAN_2024 + 5_000)
+        messages = [create_bars, SERIES_COMPLETED_MSG, modify_bars, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 8
+
+    @pytest.mark.asyncio
+    async def test_range_mode_no_segment_delay_arg_works(self) -> None:
+        """Calling get_historical_ohlcv without segment_delay uses default 0.0 silently."""
+        create_bars = make_timescale_update(bars_count=2, base_ts=_TS_JAN_2024)
+        modify_bars = make_timescale_update(bars_count=4, base_ts=_TS_JAN_2024 + 1000)
+        messages = [create_bars, SERIES_COMPLETED_MSG, modify_bars, SERIES_COMPLETED_MSG]
+
+        client = _make_range_client(messages)
+
+        with patch.multiple("tvkit.api.chart.ohlcv", **_make_patches()):
+            result = await client.get_historical_ohlcv(
+                SYMBOL, "1", start="2024-01-01", end="2024-12-31"
+            )
+
+        assert len(result) == 4

--- a/tvkit/api/chart/ohlcv.py
+++ b/tvkit/api/chart/ohlcv.py
@@ -645,6 +645,14 @@ class OHLCV:
         # We discard everything accumulated before the first series_completed and
         # only break on the second one, which carries the historical range bars.
         series_completed_count: int = 0
+        # Safety net: bars from the create_series response that fall within the
+        # requested range, saved before the first-event clear. For recent queries
+        # (e.g. sessions within the last ~83 hours at 1-minute interval),
+        # create_series already delivers the target bars. If modify_series returns
+        # nothing (throttled server, continuous futures edge case, or single-event
+        # protocol variant), these are used as a fallback instead of raising
+        # NoHistoricalDataError immediately.
+        pre_modify_bars_in_range: list[OHLCVBar] = []
 
         async for data in self.connection_service.get_data_stream():
             if loop.time() - start_time > _HISTORICAL_RANGE_TIMEOUT_SECONDS:
@@ -709,13 +717,28 @@ class OHLCV:
                     series_completed_count += 1
                     if series_completed_count == 1:
                         # First completion is the create_series response (most-recent
-                        # bars). Discard and wait for the modify_series response which
-                        # carries the actual historical range data.
-                        logger.debug(
-                            "First series_completed (create_series) — discarding %d bars, "
-                            "waiting for modify_series response.",
-                            len(historical_bars),
-                        )
+                        # bars). Before clearing, filter to the requested range and
+                        # save as a fallback — for recent queries the create_series
+                        # response may already contain the target bars. Only used if
+                        # modify_series returns nothing (see post-loop recovery below).
+                        _from_ts: int = to_unix_timestamp(start)
+                        _to_ts: int = end_of_day_timestamp(end)
+                        pre_modify_bars_in_range = [
+                            b for b in historical_bars if _from_ts <= b.timestamp <= _to_ts
+                        ]
+                        if pre_modify_bars_in_range:
+                            logger.debug(
+                                "First series_completed — saved %d in-range bars as fallback "
+                                "(discarding %d out-of-range bars, waiting for modify_series).",
+                                len(pre_modify_bars_in_range),
+                                len(historical_bars) - len(pre_modify_bars_in_range),
+                            )
+                        else:
+                            logger.debug(
+                                "First series_completed (create_series) — discarding %d bars, "
+                                "waiting for modify_series response.",
+                                len(historical_bars),
+                            )
                         historical_bars.clear()
                         continue
                     # Second series_completed is the modify_series response.
@@ -775,6 +798,24 @@ class OHLCV:
                 interval,
                 len(historical_bars),
             )
+
+        # Safety net: if modify_series returned no bars but create_series had
+        # in-range bars saved as a fallback, use those instead of raising
+        # NoHistoricalDataError. Triggered by server throttling, continuous futures
+        # data availability limits, or a single-event series_completed variant.
+        if not historical_bars and pre_modify_bars_in_range:
+            logger.info(
+                "modify_series returned no bars — falling back to %d in-range bars "
+                "from create_series response (possible server throttle or "
+                "single-event series_completed).",
+                len(pre_modify_bars_in_range),
+                extra={
+                    "symbol": canonical,
+                    "interval": interval,
+                    "fallback_bar_count": len(pre_modify_bars_in_range),
+                },
+            )
+            historical_bars = pre_modify_bars_in_range
 
         # Sort bars by timestamp for chronological order.
         historical_bars.sort(key=lambda bar: bar.timestamp)
@@ -1169,6 +1210,7 @@ class OHLCV:
         start: datetime | str | None = None,
         end: datetime | str | None = None,
         adjustment: Adjustment = Adjustment.SPLITS,
+        segment_delay: float = 0.0,
     ) -> list[OHLCVBar]:
         """
         Returns a list of historical OHLCV data for a specified symbol.
@@ -1218,6 +1260,13 @@ class OHLCV:
                 prices. Raw strings (``"splits"``, ``"dividends"``) are accepted and
                 coerced to the enum; unknown strings raise ``ValueError`` before any
                 network I/O.
+            segment_delay: Seconds to sleep between consecutive segment fetches when
+                the request is routed through ``SegmentedFetchService`` (i.e. when the
+                estimated bar count for the date range exceeds the account limit).
+                Defaults to ``0.0`` (no delay). Ignored in count mode and for ranges
+                that fit within a single request. Increase to ``1.0``–``3.0`` when
+                fetching continuous futures symbols (e.g. ``CME_MINI:MNQ1!``) to
+                reduce server-side throttling.
 
         Returns:
             A list of OHLCVBar objects sorted by timestamp in ascending order.
@@ -1278,6 +1327,7 @@ class OHLCV:
                 service = SegmentedFetchService(
                     client=self,
                     max_bars_per_segment=MAX_BARS_REQUEST,
+                    inter_segment_delay=segment_delay,
                 )
                 return await service.fetch_all(
                     exchange_symbol, interval, start_dt, end_dt, adjustment=adjustment

--- a/tvkit/api/chart/services/segmented_fetch_service.py
+++ b/tvkit/api/chart/services/segmented_fetch_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -40,15 +41,21 @@ class SegmentedFetchService:
         max_bars_per_segment: Maximum bars per segment. Defaults to ``MAX_BARS_REQUEST``
                               (5000). Lowering this value increases the number of
                               segments and reduces per-segment memory usage.
+        inter_segment_delay:  Seconds to sleep between consecutive segment fetches.
+                              Defaults to ``0.0`` (no delay). Increase this when
+                              fetching continuous futures symbols or making repeated
+                              range queries that trigger server-side throttling.
     """
 
     def __init__(
         self,
         client: OHLCV,
         max_bars_per_segment: int = MAX_BARS_REQUEST,
+        inter_segment_delay: float = 0.0,
     ) -> None:
         self._client = client
         self._max_bars_per_segment: int = max_bars_per_segment
+        self._inter_segment_delay: float = inter_segment_delay
 
     def _resolve_max_bars(self) -> int:
         """
@@ -228,6 +235,18 @@ class SegmentedFetchService:
                 logger.info("Segment complete.", extra=complete_kwargs)
             else:
                 logger.debug("Segment complete.", extra=complete_kwargs)
+
+            # Inter-segment delay: reduces server-side throttling risk for continuous
+            # futures symbols and rapid repeated range queries. Skipped after the last
+            # segment to avoid unnecessary wait at the end of the fetch.
+            if self._inter_segment_delay > 0 and i < total:
+                logger.debug(
+                    "Inter-segment delay %.2fs before segment %d/%d.",
+                    self._inter_segment_delay,
+                    i + 1,
+                    total,
+                )
+                await asyncio.sleep(self._inter_segment_delay)
 
         result: list[OHLCVBar] = self._deduplicate_and_sort(all_bars)
 


### PR DESCRIPTION
## Summary

- **Fix 1 — `series_completed` fallback:** bars from the first WebSocket event are saved before clearing; if `modify_series` never fires a second event (throttled continuous-futures queries), the saved bars are used as the result instead of raising `NoHistoricalDataError`.
- **Fix 2 — `inter_segment_delay`:** `SegmentedFetchService` accepts a configurable sleep (seconds) between consecutive segment fetches, reducing server-side throttle pressure for continuous futures.
- **Fix 3 — `segment_delay` param:** keyword-only arg on `get_historical_ohlcv()` forwarded to `SegmentedFetchService`; ignored in count mode and single-segment ranges.
- **Docs — `max_bars` window semantics:** corrected all docs to clarify that `max_bars` is a lookback window counted backward from the **latest bar in the series** (not wall-clock time), and that range mode is a filter on top of that window — not a deeper lookup.

## What changed

| File | Change |
|---|---|
| `tvkit/api/chart/ohlcv.py` | `series_completed` fallback; `segment_delay` param on `get_historical_ohlcv()` |
| `tvkit/api/chart/services/segmented_fetch_service.py` | `inter_segment_delay` param; `asyncio.sleep()` between segments |
| `tests/test_futures_range_degradation.py` | 28 new tests covering all three fixes |
| `docs/limitations.md` | Rewrote historical-depth section with window diagram and corrected figures |
| `docs/guides/historical-data.md` | Fixed `max_bars` semantics, removed phantom "Expert" tier, corrected depth table |
| `docs/internals/segmented-fetch.md` | Added `max_bars` window section + `inter_segment_delay` section |
| `docs/concepts/capabilities.md` | Added lookback-window callout |
| `docs/index.md` | Added `segmented-fetch.md` to Internals section |
| `.gitignore` | Added `.DS_Store` and `docs/issues/` |
| `CHANGELOG.md` / `pyproject.toml` | v0.11.1 release entry |

## Test plan

- [x] `uv run ruff check . && uv run ruff format . && uv run mypy tvkit/` — all pass
- [x] `uv run python -m pytest tests/test_futures_range_degradation.py -v` — 28/28 pass
- [x] `uv run python -m pytest tests/ -v` — full suite passes
- [x] Published to PyPI as `tvkit==0.11.1`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)