### PR TITLE
ci(release): automated PyPI publish + GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,168 @@
+# Triggered by version tags: v0.11.1, v1.0.0, v1.0.0-beta.1, etc.
+# Pipeline: validate tag → CI → build → publish PyPI → create GitHub Release
+#
+# One-time setup required (see docs/development/release-process.md):
+#   1. PyPI Trusted Publisher configured for this workflow + environment "pypi"
+#   2. GitHub environment "pypi" created in repo Settings → Environments
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions:
+  contents: write   # create GitHub Release + upload assets
+  id-token: write   # OIDC token for PyPI Trusted Publisher
+
+jobs:
+  # ── 1. Validate tag matches pyproject.toml version ──────────────────────────
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      is_prerelease: ${{ steps.parse.outputs.is_prerelease }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse tag and detect pre-release
+        id: parse
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$TAG" =~ -(alpha|beta|rc) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify tag matches pyproject.toml
+        run: |
+          PYPROJECT_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TAG_VERSION="${{ steps.parse.outputs.version }}"
+          if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ Version mismatch: pyproject.toml=${PYPROJECT_VERSION}, tag=${TAG_VERSION}"
+            echo "   Bump the version in pyproject.toml before tagging."
+            exit 1
+          fi
+          echo "✅ Version ${TAG_VERSION} matches pyproject.toml"
+
+  # ── 2. Full CI gate (mirrors ruff-lint.yml) ─────────────────────────────────
+  ci:
+    name: CI
+    needs: validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - run: uv python install 3.11
+      - run: uv sync --extra dev
+
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run mypy tvkit/
+      - run: uv run pytest --cov=tvkit --cov-branch -v
+
+  # ── 3. Build sdist + wheel ───────────────────────────────────────────────────
+  build:
+    name: Build
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - run: uv python install 3.11
+      - run: uv run python -m build
+
+      - name: Verify dist contents
+        run: ls -lh dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  # ── 4. Publish to PyPI (Trusted Publisher — no token needed) ─────────────────
+  publish-pypi:
+    name: Publish → PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/tvkit/${{ needs.validate.outputs.version }}/
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses OIDC Trusted Publisher — no PYPI_TOKEN secret required.
+        # Fallback: uncomment the two lines below and add PYPI_API_TOKEN to repo secrets.
+        # with:
+        #   password: ${{ secrets.PYPI_API_TOKEN }}
+
+  # ── 5. Create GitHub Release with changelog body ─────────────────────────────
+  github-release:
+    name: GitHub Release
+    needs: [validate, publish-pypi]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          python3 - "$VERSION" <<'PYEOF'
+          import re, sys
+          version = sys.argv[1]
+          content = open("CHANGELOG.md").read()
+          pattern = rf"(?m)^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)"
+          match = re.search(pattern, content, re.DOTALL)
+          notes = match.group(1).strip() if match else f"Release v{version}"
+          with open("release_notes.txt", "w") as f:
+              f.write(notes)
+          PYEOF
+          {
+            echo 'notes<<CHANGELOG_EOF'
+            cat release_notes.txt
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "tvkit v${{ needs.validate.outputs.version }}"
+          body: ${{ steps.changelog.outputs.notes }}
+          prerelease: ${{ needs.validate.outputs.is_prerelease }}
+          files: dist/*
+          make_latest: ${{ needs.validate.outputs.is_prerelease == 'false' }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # tvkit
 
+[![CI](https://github.com/lumduan/tvkit/actions/workflows/ruff-lint.yml/badge.svg)](https://github.com/lumduan/tvkit/actions/workflows/ruff-lint.yml)
+[![PyPI](https://img.shields.io/pypi/v/tvkit.svg)](https://pypi.org/project/tvkit/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/tvkit.svg)](https://pypi.org/project/tvkit/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Async/Await](https://img.shields.io/badge/async-await-green.svg)](https://docs.python.org/3/library/asyncio.html)
 [![Type Safety](https://img.shields.io/badge/typed-pydantic-red.svg)](https://pydantic.dev/)
-[![PyPI](https://img.shields.io/pypi/v/tvkit.svg)](https://pypi.org/project/tvkit/)
 
 tvkit — Async Python client for TradingView market data.
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,129 +1,199 @@
 # Release Process
 
-This page documents how to prepare, build, and publish a new tvkit release to PyPI.
+This document is the single source of truth for releasing tvkit — covering versioning strategy, the automated pipeline, manual steps, and the one-time setup required.
 
-## Prerequisites
+---
 
-- `uv` installed and `uv sync` run (all dev dependencies present)
-- PyPI project-scoped API token stored in `.env` as `PYPI_TOKEN=pypi-...`
-- All quality checks passing
-- Working on or merged into `main`
+## Versioning Strategy
 
-## Quick Release Steps
+tvkit follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
 
-1. Sync `main` from remote
-2. Run the full quality gate
-3. Bump version in `pyproject.toml`
-4. Commit, tag, and push
-5. Run `./scripts/publish.sh`
-6. Verify the package on PyPI and create a GitHub release
+| Change type | Component | Example |
+| --- | --- | --- |
+| Breaking API change | `MAJOR` | `0.x.x → 1.0.0` |
+| New feature, backwards-compatible | `MINOR` | `0.11.x → 0.12.0` |
+| Bug fix or internal improvement | `PATCH` | `0.11.1 → 0.11.2` |
 
-## Sync Repository
+### Pre-release tags
 
-Ensure the local repository is up to date before starting:
+Append a suffix to mark unstable releases:
 
-```bash
-git checkout main
-git pull origin main
+| Suffix | Meaning | Example |
+| --- | --- | --- |
+| `-beta.N` | Feature-complete, needs testing | `v0.12.0-beta.1` |
+| `-rc.N` | Release candidate, final validation | `v1.0.0-rc.1` |
+| `-alpha.N` | Early preview, may break | `v1.0.0-alpha.1` |
+
+Pre-release tags publish to PyPI with `--pre` semantics and are marked as pre-release on GitHub.
+
+### Milestone roadmap
+
+| Version | Theme | Key targets |
+| --- | --- | --- |
+| `0.11.x` | Stability | Bug fixes, improved error handling |
+| `0.12.0` | Completeness | Scanner pagination, more intervals |
+| `0.13.0` | Developer experience | Richer errors, better docs, type stubs |
+| `1.0.0` | Stable API | Frozen public contract, full coverage |
+
+Do not bump to `1.0.0` until the public API is frozen and test coverage is ≥ 90% on all public modules.
+
+---
+
+## Automated Pipeline
+
+Every version tag (`v*.*.*`) triggers `.github/workflows/release.yml`:
+
+```text
+push tag vX.Y.Z
+  │
+  ├─ validate     — tag matches pyproject.toml version
+  ├─ ci           — ruff + mypy + pytest (full suite)
+  ├─ build        — sdist + wheel via `python -m build`
+  ├─ publish-pypi — upload via PyPI Trusted Publisher (OIDC)
+  └─ github-release — extract CHANGELOG section → create GitHub Release + attach dist assets
 ```
 
-Never release from a stale local branch.
+**Both PyPI and GitHub Release are created automatically from a single tag push. You never need to do them separately.**
 
-## Pre-Release Checklist
+---
 
-Run the full quality gate:
+## One-Time Setup (do this once per repository)
+
+### 1. PyPI Trusted Publisher
+
+This replaces token-based uploads in CI. No secret is stored in GitHub.
+
+1. Log in to [pypi.org](https://pypi.org) → **Manage** → **Publishing** → **Add a new publisher**
+2. Fill in:
+   - **Owner**: `lumduan`
+   - **Repository**: `tvkit`
+   - **Workflow name**: `release.yml`
+   - **Environment**: `pypi`
+3. Save.
+
+### 2. GitHub Environment
+
+1. Go to **Settings → Environments → New environment**
+2. Name it exactly `pypi`
+3. (Optional but recommended) Add a required reviewer so no release can go out without approval
+
+### 3. `softprops/action-gh-release` permissions
+
+The workflow already sets `permissions: contents: write`. No extra token is needed.
+
+---
+
+## Release Checklist
+
+Follow these steps for every release, in order.
+
+### Before bumping the version
+
+- [ ] All work for this release is merged to `main`
+- [ ] `git pull origin main` — local branch is current
+- [ ] Quality gate passes:
+
+  ```bash
+  uv run ruff check . && uv run ruff format . && uv run mypy tvkit/
+  uv run python -m pytest tests/ -v
+  ```
+
+- [ ] `CHANGELOG.md` has a section for the new version with date and full notes
+
+### Bump and tag
 
 ```bash
-uv run ruff check . && uv run ruff format . && uv run mypy tvkit/
-uv run python -m pytest tests/ -v
-```
+# 1. Update version in pyproject.toml
+#    Change: version = "0.11.1"  →  version = "0.12.0"
 
-All checks must pass. Do not publish a release with failing tests or type errors.
+# 2. Commit the version bump
+git add pyproject.toml CHANGELOG.md
+git commit -m "chore(release): bump version to v0.12.0"
 
-## Version Bump
+# 3. Tag the commit
+git tag v0.12.0
 
-Version is declared in `pyproject.toml`:
-
-```toml
-[project]
-version = "0.3.0"
-```
-
-tvkit follows [Semantic Versioning](https://semver.org/):
-
-| Change type | Version component | Example |
-|-------------|-------------------|---------|
-| Backwards-incompatible API change | Major (`X.0.0`) | `0.3.0` → `1.0.0` |
-| New feature, backwards-compatible | Minor (`0.X.0`) | `0.3.0` → `0.4.0` |
-| Bug fix or internal change | Patch (`0.0.X`) | `0.3.0` → `0.3.1` |
-
-Update the version in `pyproject.toml`, commit the change, and tag the commit:
-
-```bash
-git add pyproject.toml
-git commit -m "release: bump version to vX.Y.Z"
-git tag vX.Y.Z
+# 4. Push branch and tag together
 git push origin main --tags
 ```
 
-## Build
+Pushing the tag starts the automated pipeline. Watch it at:
+`https://github.com/lumduan/tvkit/actions`
 
-Clean previous build artifacts before building to avoid uploading stale files:
+### After the pipeline completes
+
+- [ ] Verify PyPI: `https://pypi.org/project/tvkit/0.12.0/`
+- [ ] Test installation in a clean environment:
+
+  ```bash
+  pip install tvkit==0.12.0
+  ```
+
+- [ ] Verify GitHub Release: `https://github.com/lumduan/tvkit/releases/tag/v0.12.0`
+  - Release notes match the CHANGELOG section
+  - Both `.whl` and `.tar.gz` assets are attached
+- [ ] Mark the release as **Latest** if this is a stable release (the workflow does this automatically for non-pre-release tags)
+
+---
+
+## Manual Fallback (if automation fails)
+
+If the GitHub Actions pipeline fails after a tag is already pushed:
 
 ```bash
-rm -rf dist/ build/ *.egg-info
-uv run python3 -m build
-```
+# Rebuild
+rm -rf dist/ build/
+uv run python -m build
 
-Output goes to `dist/`. The publish script validates that `dist/` is non-empty before uploading.
-
-## Publishing
-
-Use the publish script:
-
-```bash
+# Publish to PyPI manually
 ./scripts/publish.sh
+
+# Create GitHub Release manually
+gh release create v0.12.0 dist/* \
+  --title "tvkit v0.12.0" \
+  --notes-file <(awk '/^## \[0\.12\.0\]/,/^## \[/' CHANGELOG.md | head -n -1 | tail -n +2)
 ```
 
-The script:
-1. Reads `PYPI_TOKEN` from `.env`
-2. Validates the token starts with `pypi-`
-3. Builds the package with `python -m build`
-4. Prompts for confirmation before uploading
-5. Uploads to production PyPI with `twine`
+Never skip the GitHub Release step — **every PyPI publish must have a matching GitHub Release**.
 
-The script publishes to **production PyPI** — not TestPyPI. Verify the version number and quality checks before confirming the prompt.
+---
 
-### Optional: Verify with TestPyPI First
+## CHANGELOG Format
 
-To test the upload without affecting production:
+Every release section must follow this format so the automation can extract it cleanly:
 
-```bash
-uv run python3 -m twine upload --repository testpypi dist/* --username __token__ --password "$PYPI_TOKEN"
+```markdown
+## [0.12.0] — 2026-05-15
+
+### Added
+- New feature description
+
+### Changed
+- What changed and why
+
+### Fixed
+- Bug that was fixed
+
+### Removed
+- What was removed (include migration path if breaking)
 ```
 
-Note: TestPyPI uses a separate token from a separate account (`test.pypi.org`).
+Rules:
 
-## Post-Release
+- The header must be exactly `## [VERSION] — YYYY-MM-DD`
+- Add the new section at the **top** of the file, above the previous release
+- Every public API change needs an entry
 
-After a successful publish:
+---
 
-1. Verify the release at `https://pypi.org/project/tvkit/`
-2. Test installation: `pip install tvkit==X.Y.Z`
-3. Create a GitHub release for the tag `vX.Y.Z` with release notes
-4. Update `CHANGELOG.md` if maintained
+## Local Publishing (reference)
 
-## PyPI Token Setup
+`./scripts/publish.sh` is the manual publish path. It reads `PYPI_TOKEN` from `.env`, builds, and uploads. Use this only when you need to bypass CI (e.g., fixing a broken release quickly). Always follow up with a manual `gh release create` afterward.
 
-Generate a project-scoped token at `https://pypi.org/manage/project/tvkit/settings/` (requires a PyPI account with maintainer access). Store it in a `.env` file at the project root:
-
-```text
-PYPI_TOKEN=pypi-your-token-here
-```
-
-The `.env` file is gitignored. Never commit a PyPI token to version control.
+---
 
 ## See Also
 
 - [Testing Strategy](testing-strategy.md) — quality gates required before release
-- [Architecture Decisions](architecture-decisions.md) — why certain design choices were made
+- [Architecture Decisions](architecture-decisions.md) — design rationale
+- [Workflow file](../../.github/workflows/release.yml) — the automation itself


### PR DESCRIPTION
## Summary

- **New** `.github/workflows/release.yml` — tag-triggered pipeline: validate → CI → build → publish to PyPI (OIDC Trusted Publisher) → create GitHub Release with changelog body extracted from `CHANGELOG.md` automatically
- **Updated** `README.md` — adds CI status badge and PyPI monthly downloads badge
- **Rewritten** `docs/development/release-process.md` — single authoritative release guide covering versioning strategy, milestone roadmap, one-time setup steps, full release checklist, and manual fallback

## How it works

Push a version tag and everything happens automatically:

\`\`\`bash
git tag v0.12.0
git push origin main --tags
\`\`\`

Pipeline stages:
1. **validate** — confirms tag matches `pyproject.toml` version
2. **ci** — ruff + mypy + pytest full gate
3. **build** — sdist + wheel via `python -m build`
4. **publish-pypi** — OIDC Trusted Publisher (no token secrets in GitHub)
5. **github-release** — extracts matching `## [x.y.z]` block from `CHANGELOG.md`, creates release, attaches dist assets

## One-time setup required before first use

- [ ] Configure PyPI Trusted Publisher: pypi.org → Manage → Publishing → add `release.yml` + environment `pypi`
- [ ] Create GitHub Environment named `pypi` in repo Settings → Environments

## Test plan

- [ ] Merge to `main`
- [ ] Complete PyPI Trusted Publisher + GitHub Environment setup
- [ ] Tag `v0.11.1` (or next version) and push — verify all 5 workflow jobs pass
- [ ] Confirm PyPI release page and GitHub Release both appear with correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)