### PR TITLE
ci(release): fix GitHub Release changelog extraction heredoc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,12 @@ jobs:
           pattern = rf"(?m)^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## \[|\Z)"
           match = re.search(pattern, content, re.DOTALL)
           notes = match.group(1).strip() if match else f"Release v{version}"
+          notes = notes.rstrip("-").rstrip()  # drop trailing '---' changelog separator
           with open("release_notes.txt", "w") as f:
-              f.write(notes)
+              # Trailing newline keeps the closing GITHUB_OUTPUT heredoc delimiter
+              # ('CHANGELOG_EOF') on its own line — otherwise the job fails with
+              # "Matching delimiter not found".
+              f.write(notes + "\n")
           PYEOF
           {
             echo 'notes<<CHANGELOG_EOF'


### PR DESCRIPTION
## Problem
The v0.11.2 Release run succeeded through `Validate → CI → Build → Publish → PyPI`, but the final **`GitHub Release`** job failed at *Extract changelog section*:

```
##[error]Invalid value. Matching delimiter not found 'CHANGELOG_EOF'
```

Run: https://github.com/lumduan/tvkit/actions/runs/27589356753

The step wrote the notes with no trailing newline, so `cat release_notes.txt` put the content and the closing `GITHUB_OUTPUT` heredoc delimiter (`CHANGELOG_EOF`) on the **same line**. This path executed for the first time on v0.11.2 — for v0.11.1 the `publish-pypi` job failed, so `github-release` was skipped.

(The v0.11.2 GitHub Release was created manually as a one-off workaround; this fixes the automation for future tags.)

## Fix
In the *Extract changelog section* step:
- `f.write(notes + "\n")` — trailing newline keeps `CHANGELOG_EOF` on its own line.
- `notes.rstrip("-").rstrip()` — drops the trailing `---` changelog separator from the release body.

Verified locally: the section extracts cleanly and the simulated `GITHUB_OUTPUT` has the closing delimiter on its own line. YAML still parses.

Note: this only touches `.github/workflows/release.yml`, so `ruff-lint.yml` (path-filtered) does not run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)