### PR TITLE
ci: bump GitHub Actions to current (Node 24) major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       is_prerelease: ${{ steps.parse.outputs.is_prerelease }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse tag and detect pre-release
         id: parse
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           enable-cache: true
@@ -83,9 +83,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           enable-cache: true
@@ -97,7 +97,7 @@ jobs:
       - name: Verify dist contents
         run: ls -lh dist/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -113,7 +113,7 @@ jobs:
       url: https://pypi.org/project/tvkit/${{ needs.validate.outputs.version }}/
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -135,9 +135,9 @@ jobs:
     if: always() && needs.validate.result == 'success' && needs.publish-pypi.result != 'failure'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -167,7 +167,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "tvkit v${{ needs.validate.outputs.version }}"
           body: ${{ steps.changelog.outputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/ruff-lint.yml
+++ b/.github/workflows/ruff-lint.yml
@@ -28,9 +28,9 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           enable-cache: true
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: ruff
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           version: "latest"
           enable-cache: true
@@ -62,7 +62,7 @@ jobs:
       - run: uv run pytest --cov=tvkit --cov-branch --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: coverage.xml
           flags: unittests

--- a/.github/workflows/ruff-lint.yml
+++ b/.github/workflows/ruff-lint.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
Clears the **"Node.js 20 actions are deprecated"** warnings that appeared in the v0.11.2 Release run.

Every Node-based action moved to its current major (latest verified via the GitHub Releases API):

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v6 |
| astral-sh/setup-uv | v5 | v8 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| softprops/action-gh-release | v2 | v3 |
| codecov/codecov-action | v4 | v7 |

`pypa/gh-action-pypi-publish@release/v1` is a container (Docker) action, not Node-based, so it's left unchanged.

Touches `release.yml` and `ruff-lint.yml`. Because it edits `ruff-lint.yml`, this PR runs the CI workflow itself with the bumped actions — so a green run here also confirms the new versions work and the Node 20 warnings are gone. (The `release.yml` bumps only execute on a tag; their interfaces are unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)