### PR TITLE
fix(scanner): report unparseable rows instead of discarding them silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Scanner: unparseable rows are now reported instead of silently discarded**
+  (`tvkit.api.scanner.models.scanner`)  
+  `ScannerResponse.from_api_response()` skipped rows it could not parse behind a bare
+  `except Exception: continue` with no logging. That made `len(data) < total_count` ambiguous —
+  it could mean either "the requested range was smaller" or "rows were thrown away" — and it hid
+  a real defect in which every US and UK row failed validation, so `scan_market()` returned zero
+  rows while reporting `total_count=4943`. Now each discarded row is logged at `WARNING` with its
+  index, symbol and the underlying error, followed by a one-line summary, and the total is exposed
+  on the new `ScannerResponse.dropped_row_count` field (default `0`), so a pipeline can assert
+  `response.dropped_row_count == 0`. Rows are still skipped rather than raising, so a single bad
+  record cannot discard a whole response.
+- **Scanner: caller errors are no longer swallowed** (`tvkit.api.scanner.models.scanner`)  
+  The same `except` clause is narrowed from `Exception` to `ValueError` (which covers pydantic's
+  `ValidationError`). A malformed *payload* is still skipped, but a bug in the *call* — for example
+  passing `columns=None` — now raises instead of returning an empty response.
+
+  **Migration:** none required. `dropped_row_count` is additive with a default, and the narrowed
+  `except` only surfaces errors that were previously hidden. If you assert on the exact key set of
+  `ScannerResponse.model_dump()`, add `dropped_row_count`.
+
 ## [0.12.0] — 2026-08-17
 
 ### Added

--- a/docs/reference/scanner/scanner.md
+++ b/docs/reference/scanner/scanner.md
@@ -367,6 +367,7 @@ from tvkit.api.scanner.models import ScannerResponse
 | `data` | `list[StockData]` | required | List of matched stocks |
 | `total_count` | `int \| None` | `None` | Total number of results available in the market (use for pagination math). Populated from the `totalCount` field in the TradingView response. |
 | `next_page_token` | `str \| None` | `None` | Reserved; mapped from `nextPageToken` in the API response. TradingView does not currently return this field — use `range_start` / `range_end` for pagination instead (see [Pagination](#pagination)). |
+| `dropped_row_count` | `int` | `0` | Rows present in the API payload that could not be parsed and were discarded. Non-zero means data loss — `len(data)` is short by this many rows for a reason unrelated to the requested range. Each drop is logged at `WARNING`. |
 
 ### `StockData`
 

--- a/tests/test_scanner_row_drop.py
+++ b/tests/test_scanner_row_drop.py
@@ -1,0 +1,111 @@
+"""Tests for scanner row-drop reporting.
+
+``ScannerResponse.from_api_response`` skips rows it cannot parse so that one bad record
+cannot discard a whole response. It used to do so behind a bare ``except Exception:
+continue`` with no logging, which made ``len(data) < total_count`` ambiguous — it could
+mean either "the requested range was smaller" or "we threw your data away". Every drop is
+now counted on ``dropped_row_count`` and logged at WARNING.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from tvkit.api.scanner.models.scanner import ScannerResponse
+
+COLUMNS: list[str] = ["name", "close", "volume"]
+
+GOOD_ROW: dict[str, Any] = {"s": "NASDAQ:AAPL", "d": ["AAPL", 305.59, 38169263]}
+BAD_VALUE_ROW: dict[str, Any] = {"s": "NASDAQ:MSFT", "d": ["MSFT", "not-a-number", 22118613]}
+SHORT_ROW: dict[str, Any] = {"s": "NASDAQ:NVDA", "d": ["NVDA", 225.01]}
+
+
+def test_clean_response_reports_no_drops() -> None:
+    """A fully parseable payload leaves dropped_row_count at zero."""
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    parsed = ScannerResponse.from_api_response(response, COLUMNS)
+
+    assert len(parsed.data) == 1
+    assert parsed.dropped_row_count == 0
+
+
+def test_clean_response_logs_nothing() -> None:
+    """No warning is emitted when nothing is discarded."""
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    logger = logging.getLogger("tvkit.api.scanner.models.scanner")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append  # type: ignore[method-assign]
+    logger.addHandler(handler)
+    try:
+        ScannerResponse.from_api_response(response, COLUMNS)
+    finally:
+        logger.removeHandler(handler)
+
+    assert records == []
+
+
+def test_unparseable_rows_are_counted_not_hidden() -> None:
+    """Rows that fail validation are skipped but reported via dropped_row_count."""
+    response: dict[str, Any] = {
+        "data": [GOOD_ROW, BAD_VALUE_ROW, SHORT_ROW],
+        "totalCount": 3,
+    }
+
+    parsed = ScannerResponse.from_api_response(response, COLUMNS)
+
+    assert [s.name for s in parsed.data] == ["AAPL"]
+    assert parsed.dropped_row_count == 2, "silent data loss — the drop was not reported"
+    # The shortfall is now explainable: 3 rows in, 1 out, 2 accounted for.
+    assert len(parsed.data) + parsed.dropped_row_count == len(response["data"])
+
+
+def test_dropped_row_count_survives_serialization() -> None:
+    """The count is a real field, so a pipeline can assert on a dumped response."""
+    response: dict[str, Any] = {"data": [GOOD_ROW, SHORT_ROW], "totalCount": 2}
+
+    dumped = ScannerResponse.from_api_response(response, COLUMNS).model_dump()
+
+    assert dumped["dropped_row_count"] == 1
+
+
+def test_each_drop_is_logged_with_index_and_symbol(caplog: pytest.LogCaptureFixture) -> None:
+    """Each discarded row is logged at WARNING, naming the row and the symbol."""
+    response: dict[str, Any] = {
+        "data": [GOOD_ROW, BAD_VALUE_ROW, SHORT_ROW],
+        "totalCount": 3,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="tvkit.api.scanner.models.scanner"):
+        ScannerResponse.from_api_response(response, COLUMNS)
+
+    per_row = [r for r in caplog.records if getattr(r, "row_index", None) is not None]
+    assert len(per_row) == 2
+    assert {r.row_index for r in per_row} == {1, 2}  # type: ignore[attr-defined]
+    assert {r.symbol for r in per_row} == {"NASDAQ:MSFT", "NASDAQ:NVDA"}  # type: ignore[attr-defined]
+
+    summary = [r for r in caplog.records if getattr(r, "dropped_row_count", None) is not None]
+    assert len(summary) == 1
+    assert summary[0].dropped_row_count == 2  # type: ignore[attr-defined]
+
+
+def test_caller_errors_are_no_longer_swallowed() -> None:
+    """A bug in the call — not in the payload — must surface, not vanish.
+
+    The previous bare ``except Exception`` turned this into an empty response.
+    """
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    with pytest.raises(TypeError):
+        ScannerResponse.from_api_response(response, None)  # type: ignore[arg-type]
+
+
+def test_missing_data_key_yields_an_empty_response() -> None:
+    """A payload with no 'data' key is empty, not a drop."""
+    parsed = ScannerResponse.from_api_response({"totalCount": 0}, COLUMNS)
+
+    assert parsed.data == []
+    assert parsed.dropped_row_count == 0

--- a/tvkit/api/scanner/models/scanner.py
+++ b/tvkit/api/scanner/models/scanner.py
@@ -5,9 +5,12 @@ This module provides Pydantic models for interacting with the TradingView
 scanner API, including request payloads and response parsing.
 """
 
+import logging
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class SortConfig(BaseModel):
@@ -314,6 +317,15 @@ class ScannerResponse(BaseModel):
     next_page_token: str | None = Field(
         default=None, description="Token for retrieving next page of results"
     )
+    dropped_row_count: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of rows present in the API payload that could not be parsed and were "
+            "discarded. Non-zero means data loss: len(data) is short by this many rows for a "
+            "reason unrelated to the requested range. Each drop is logged at WARNING."
+        ),
+    )
 
     @classmethod
     def from_api_response(
@@ -339,8 +351,9 @@ class ScannerResponse(BaseModel):
         """
         # Parse rows into StockData instances
         stocks: list[StockData] = []
+        dropped: int = 0
         if "data" in response_data:
-            for item in response_data["data"]:
+            for index, item in enumerate(response_data["data"]):
                 try:
                     # Handle new API format: {"s": "NASDAQ:AAPL", "d": [data_array]}
                     if isinstance(item, dict) and "d" in item:
@@ -360,15 +373,40 @@ class ScannerResponse(BaseModel):
 
                     stock = StockData.from_scanner_row(row_data, columns)
                     stocks.append(stock)
-                except Exception:
-                    # Log error but continue processing other rows
-                    # In production, you'd want proper logging here
+                except ValueError as exc:
+                    # Malformed upstream row: wrong length, or a value that fails validation.
+                    # pydantic's ValidationError subclasses ValueError, so both land here.
+                    # Skip the row so one bad record cannot discard a whole response, but never
+                    # skip it silently — see the dropped_row_count field.
+                    dropped += 1
+                    symbol_label: str = (
+                        str(item.get("s"))
+                        if isinstance(item, dict) and "s" in item
+                        else "<unknown>"
+                    )
+                    logger.warning(
+                        "Discarding unparseable scanner row %d (%s): %s",
+                        index,
+                        symbol_label,
+                        exc,
+                        extra={"row_index": index, "symbol": symbol_label},
+                    )
                     continue
+
+        if dropped:
+            logger.warning(
+                "Scanner response: discarded %d of %d row(s); len(data)=%d",
+                dropped,
+                len(response_data.get("data", [])),
+                len(stocks),
+                extra={"dropped_row_count": dropped},
+            )
 
         return cls(
             data=stocks,
             total_count=response_data.get("totalCount"),
             next_page_token=response_data.get("nextPageToken"),
+            dropped_row_count=dropped,
         )
 
 


### PR DESCRIPTION
## Summary

`ScannerResponse.from_api_response()` skipped rows it could not parse behind a bare
`except Exception: continue` with no logging — the clause's own comment conceded the gap
(*"In production, you'd want proper logging here"*), and the module had no logger at all.

That made `len(data) < total_count` **ambiguous by construction**: it could mean either "the
requested range was smaller" or "we threw your data away", and a caller could not tell which. It
also hid a real defect in which every US and UK row failed validation, so `scan_market()` returned
**zero rows while reporting `total_count=4943`** — a perfectly valid `ScannerResponse` that had
simply stopped carrying data.

This PR keeps the skip-don't-raise behaviour (one bad record should not discard a whole response)
but makes every drop visible, to humans and to programs.

---

## Related issues

- Closes #43

---

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (no behaviour change — code structure or performance improvement)
- [ ] Documentation (docs, docstrings, or examples only)
- [x] Tests (adding or updating tests only)
- [ ] Breaking change (changes existing behaviour or public API)
- [ ] Chore (CI, build system, dependencies, tooling)
- [ ] Other (describe below)

---

## What changed

| Change | Why |
|---|---|
| Added a module logger; each discarded row logs at `WARNING` with its index, the symbol from `item["s"]`, and the underlying error, followed by a one-line summary | The silence was the defect. This is what would have made the `market_cap_basic` bug obvious on day one. |
| Added `ScannerResponse.dropped_row_count: int = 0` | Logs are for humans. A pipeline needs `assert response.dropped_row_count == 0`. |
| Narrowed `except Exception` → `except ValueError` | pydantic's `ValidationError` subclasses `ValueError`, so a malformed *payload* row is still skipped — but a bug in the *call* (e.g. `columns=None`) now raises instead of returning an empty response. |

`len(data) + dropped_row_count == len(payload["data"])` now holds, so the shortfall is always
explainable.

---

## Verification against the live API

This branch is cut from `main`, so the `market_cap_basic` type error (fixed separately in #40) is
still present here — which makes it an ideal end-to-end test. Same call, before and after:

**Before** — a valid response object carrying nothing, and no way to tell why:

```text
rows returned      : 0
total_count        : 4943
```

**After** — the same underlying failure, now impossible to miss:

```text
WARNING  Discarding unparseable scanner row 0 (NASDAQ:NVDA): 1 validation error for StockData
         market_cap_basic
           Input should be a valid integer, got a number with a fractional part
           [type=int_from_float, input_value=5445242088563.96, input_type=float]
WARNING  Discarding unparseable scanner row 1 (NASDAQ:AAPL): 1 validation error for StockData
         market_cap_basic
           Input should be a valid integer, got a number with a fractional part
           [type=int_from_float, input_value=4459835263931.044, input_type=float]
...
WARNING  Scanner response: discarded 24 of 25 row(s); len(data)=1

rows returned      : 1
total_count        : 4943
dropped_row_count  : 24
```

Once #40 merges, that same run reports `dropped_row_count: 0`.

---

## Quality gates

- [x] `uv run ruff check .` — lint passes
- [x] `uv run ruff format .` — formatting applied
- [x] `uv run mypy tvkit/` — type checking passes
- [x] `uv run python -m pytest tests/ -v` — 1111 passed, 2 skipped

`./scripts/check-docs.sh` is unchanged from `main` (the same 4 pre-existing link findings).

---

## Tests

- [x] Tests added or updated to cover this change
- [x] All existing tests still pass

`tests/test_scanner_row_drop.py` is new — 7 tests, all network-free:

- a clean payload reports `dropped_row_count == 0` **and logs nothing**
- a payload with a bad value and a short row keeps the good row, counts both drops, and satisfies
  `len(data) + dropped_row_count == len(payload)`
- the count survives `model_dump()`, so it is assertable on a serialized response
- each drop logs at `WARNING` carrying `row_index` and `symbol` in `extra`, plus one summary record
  carrying `dropped_row_count`
- `columns=None` now raises `TypeError` rather than silently returning an empty response
- a payload with no `data` key is empty, not a drop

---

## Documentation

- [x] Docstrings updated for new or changed public functions
- [x] `docs/` updated (if behaviour or APIs changed)
- [x] `examples/` verified or updated (if applicable)

`docs/reference/scanner/scanner.md` gains `dropped_row_count` in the `ScannerResponse` field table.
`CHANGELOG.md` gains an `[Unreleased]` section describing both changes with a migration note.

---

## Breaking changes

- [ ] This PR introduces breaking changes

Additive and non-breaking: the new field has a default, and the narrowed `except` only surfaces
errors that were previously hidden. The one thing to know: **if you assert on the exact key set of
`ScannerResponse.model_dump()`, add `dropped_row_count`.**

---

## Additional notes

**Merge order with #40.** These two are independent and touch different functions in
`tvkit/api/scanner/models/scanner.py` (`StockData.market_cap_basic` vs
`ScannerResponse.from_api_response`), so they merge in either order without conflict. #40 fixes the
type error; this PR fixes the mechanism that hid it. Landing both is what closes the loop —
otherwise the next such error is just as invisible.

**Deliberately not changed:** rows are still skipped rather than raising. Making a bad row fatal
would be a genuine behaviour change and a worse default for a screener over thousands of symbols.
Callers who want strictness now have `dropped_row_count` to enforce it themselves.

**One adjacent gap left alone:** a payload with no `data` key at all still yields an empty response
without comment. That is plausibly legitimate for an empty result set, so it did not seem worth a
warning — happy to add one if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
