### PR TITLE
fix(export): let to_polars() choose the timestamp dtype so the pipeline composes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Scanner: unparseable rows are now reported instead of silently discarded**
+  (`tvkit.api.scanner.models.scanner`)  
+  `ScannerResponse.from_api_response()` skipped rows it could not parse behind a bare
+  `except Exception: continue` with no logging. That made `len(data) < total_count` ambiguous —
+  it could mean either "the requested range was smaller" or "rows were thrown away" — and it hid
+  a real defect in which every US and UK row failed validation, so `scan_market()` returned zero
+  rows while reporting `total_count=4943`. Now each discarded row is logged at `WARNING` with its
+  index, symbol and the underlying error, followed by a one-line summary, and the total is exposed
+  on the new `ScannerResponse.dropped_row_count` field (default `0`), so a pipeline can assert
+  `response.dropped_row_count == 0`. Rows are still skipped rather than raising, so a single bad
+  record cannot discard a whole response.
+- **Scanner: caller errors are no longer swallowed** (`tvkit.api.scanner.models.scanner`)  
+  The same `except` clause is narrowed from `Exception` to `ValueError` (which covers pydantic's
+  `ValidationError`). A malformed *payload* is still skipped, but a bug in the *call* — for example
+  passing `columns=None` — now raises instead of returning an empty response.
+
+  **Migration:** none required. `dropped_row_count` is additive with a default, and the narrowed
+  `except` only surfaces errors that were previously hidden. If you assert on the exact key set of
+  `ScannerResponse.model_dump()`, add `dropped_row_count`.
+
 ## [0.12.0] — 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`DataExporter.to_polars(timestamp_format=...)`** (`tvkit.export`)  
+  New keyword-only argument selecting the dtype of the `timestamp` column for OHLCV input:
+  `"iso"` (default, unchanged — `String` ISO-8601 text), `"unix"` (`Float64` epoch seconds), or
+  `"datetime"` (tz-aware `Datetime(time_unit="us", time_zone="UTC")`). Previously `to_polars()`
+  hard-coded the default `ExportConfig`, so its `String` column could not be changed without
+  dropping down to `export_ohlcv_data()` with a hand-built config — and that `String` column is
+  rejected by both `validate_ohlcv()` and `convert_to_timezone()`, meaning tvkit's own documented
+  fetch → export → validate/convert pipeline did not compose. `"unix"` and `"datetime"` are now
+  accepted by both consumers. Ignored for scanner and fundamentals input, whose timestamp-like
+  columns are always ISO strings.
+
+### Changed
+
+- **`convert_to_timezone()` accepts an existing `Datetime` column** (`tvkit.time`)  
+  A column that is already temporal skips the epoch-decode step and is only re-zoned; a naive
+  column is assumed UTC, consistent with `to_utc()`. This makes
+  `to_polars(timestamp_format="datetime")` chain directly into a timezone conversion.
+- **Actionable errors for a non-numeric timestamp column** (`tvkit.time`, `tvkit.validation`)  
+  `convert_to_timezone()` previously let polars raise `InvalidOperationError: arithmetic on string
+  and numeric not allowed`, which named neither the column nor the fix. It now raises `ValueError`
+  identifying the column, its dtype, and the `timestamp_format` argument to pass.
+  `validate_ohlcv()`'s existing dtype error gains the same hint when the column is a `String`.
+
+  **Migration:** none required. `timestamp_format` defaults to the previous behaviour. If you
+  caught `polars.exceptions.InvalidOperationError` around `convert_to_timezone()`, catch
+  `ValueError` instead.
+
 ## [0.12.0] — 2026-08-17
 
 ### Added

--- a/docs/reference/export/exporter.md
+++ b/docs/reference/export/exporter.md
@@ -229,6 +229,8 @@ async def to_polars(
     self,
     data: list[OHLCVBar] | list[StockData],
     add_analysis: bool = False,
+    *,
+    timestamp_format: Literal["iso", "unix", "datetime"] = "iso",
 ) -> pl.DataFrame: ...
 ```
 
@@ -238,6 +240,18 @@ async def to_polars(
 |-----------|------|---------|-------------|
 | `data` | `list[OHLCVBar] \| list[StockData]` | required | OHLCV bars or scanner rows |
 | `add_analysis` | `bool` | `False` | When `True` and data is `list[OHLCVBar]`, adds financial analysis columns (SMA, VWAP, etc.) to the DataFrame |
+| `timestamp_format` | `Literal["iso", "unix", "datetime"]` | `"iso"` | Dtype of the `timestamp` column for OHLCV input. Keyword-only. `"iso"` → `String` ISO-8601 text; `"unix"` → `Float64` epoch seconds; `"datetime"` → tz-aware `Datetime(time_unit="us", time_zone="UTC")`. Ignored for scanner and fundamentals input. |
+
+> **Chaining into validation or timezone conversion.** The default `"iso"` gives a readable
+> `String` column, which [`validate_ohlcv()`](../validation/validate_ohlcv.md) and
+> [`convert_to_timezone()`](../time/index.md) both reject. Pass `timestamp_format="unix"` when the
+> frame is going on to either of them:
+>
+> | `timestamp_format` | dtype | `validate_ohlcv()` | `convert_to_timezone()` |
+> |---|---|---|---|
+> | `"iso"` (default) | `String` | ✗ | ✗ |
+> | `"unix"` | `Float64` | ✓ | ✓ |
+> | `"datetime"` | `Datetime(us, UTC)` | ✓ | ✓ |
 
 #### Returns
 

--- a/docs/reference/scanner/scanner.md
+++ b/docs/reference/scanner/scanner.md
@@ -367,6 +367,7 @@ from tvkit.api.scanner.models import ScannerResponse
 | `data` | `list[StockData]` | required | List of matched stocks |
 | `total_count` | `int \| None` | `None` | Total number of results available in the market (use for pagination math). Populated from the `totalCount` field in the TradingView response. |
 | `next_page_token` | `str \| None` | `None` | Reserved; mapped from `nextPageToken` in the API response. TradingView does not currently return this field — use `range_start` / `range_end` for pagination instead (see [Pagination](#pagination)). |
+| `dropped_row_count` | `int` | `0` | Rows present in the API payload that could not be parsed and were discarded. Non-zero means data loss — `len(data)` is short by this many rows for a reason unrelated to the requested range. Each drop is logged at `WARNING`. |
 
 ### `StockData`
 

--- a/tests/test_export_timestamp_format.py
+++ b/tests/test_export_timestamp_format.py
@@ -1,0 +1,131 @@
+"""Tests for ``DataExporter.to_polars(timestamp_format=...)`` and its consumers.
+
+``to_polars()`` used to hard-code the default ``ExportConfig``, whose ``timestamp_format`` is
+``"iso"`` — a ``String`` column that both :func:`tvkit.validation.validate_ohlcv` and
+:func:`tvkit.time.convert_to_timezone` reject. There was no way to ask ``to_polars()`` for a
+numeric column, so tvkit's own documented pipeline did not compose.
+"""
+
+from datetime import UTC, datetime
+
+import polars as pl
+import pytest
+
+from tvkit.api.chart.models.ohlcv import OHLCVBar
+from tvkit.export import DataExporter
+from tvkit.time import convert_to_exchange_timezone, convert_to_timezone
+from tvkit.validation import validate_ohlcv
+
+# Three consecutive daily bars, 2026-01-01..03 UTC. Synthetic — no network.
+BARS: list[OHLCVBar] = [
+    OHLCVBar(timestamp=1767225600.0, open=100.0, high=101.0, low=99.0, close=100.5, volume=1000.0),
+    OHLCVBar(timestamp=1767312000.0, open=100.5, high=102.0, low=100.0, close=101.5, volume=1200.0),
+    OHLCVBar(timestamp=1767398400.0, open=101.5, high=103.0, low=101.0, close=102.5, volume=1100.0),
+]
+
+
+@pytest.fixture
+def exporter() -> DataExporter:
+    return DataExporter()
+
+
+@pytest.mark.asyncio
+async def test_default_is_unchanged(exporter: DataExporter) -> None:
+    """Omitting the argument must behave exactly as before — a String column."""
+    df = await exporter.to_polars(BARS)
+
+    assert df["timestamp"].dtype == pl.String
+    assert df["timestamp"][0] == "2026-01-01T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fmt", "expected"),
+    [
+        ("iso", pl.String),
+        ("unix", pl.Float64),
+        ("datetime", pl.Datetime(time_unit="us", time_zone="UTC")),
+    ],
+)
+async def test_timestamp_format_selects_the_dtype(
+    exporter: DataExporter, fmt: str, expected: pl.DataType
+) -> None:
+    """Each accepted value produces the documented dtype."""
+    df = await exporter.to_polars(BARS, timestamp_format=fmt)  # type: ignore[arg-type]
+
+    assert df["timestamp"].dtype == expected
+
+
+@pytest.mark.asyncio
+async def test_timestamp_format_is_keyword_only(exporter: DataExporter) -> None:
+    """It must not be passable positionally, where it would collide with add_analysis."""
+    with pytest.raises(TypeError):
+        await exporter.to_polars(BARS, False, "unix")  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_invalid_timestamp_format_is_rejected(exporter: DataExporter) -> None:
+    """ExportConfig validates the value, so a typo fails loudly."""
+    with pytest.raises(ValueError, match="timestamp_format"):
+        await exporter.to_polars(BARS, timestamp_format="epoch")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["unix", "datetime"])
+async def test_numeric_and_temporal_frames_validate(exporter: DataExporter, fmt: str) -> None:
+    """The whole point: the frame chains straight into validate_ohlcv()."""
+    df = await exporter.to_polars(BARS, timestamp_format=fmt)  # type: ignore[arg-type]
+
+    result = validate_ohlcv(df, interval="1D")
+
+    assert result.is_valid
+    assert result.bars_checked == len(BARS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt", ["unix", "datetime"])
+async def test_numeric_and_temporal_frames_convert_timezone(
+    exporter: DataExporter, fmt: str
+) -> None:
+    """...and straight into a timezone conversion."""
+    df = await exporter.to_polars(BARS, timestamp_format=fmt)  # type: ignore[arg-type]
+
+    local = convert_to_exchange_timezone(df, "NASDAQ")
+
+    assert local["timestamp"].dtype == pl.Datetime(time_unit="us", time_zone="America/New_York")
+    # The instant is preserved, only its rendering changes: 2026-01-01T00:00Z is 19:00 on
+    # 2025-12-31 in New York (UTC-5).
+    assert local["timestamp"][0] == datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    assert (local["timestamp"][0].hour, local["timestamp"][0].day) == (19, 31)
+    # The source frame is never mutated.
+    assert df["timestamp"].dtype != pl.Datetime(time_unit="us", time_zone="America/New_York")
+
+
+@pytest.mark.asyncio
+async def test_iso_frame_names_the_fix_in_the_validation_error(exporter: DataExporter) -> None:
+    """The default still fails — but the message says what to pass instead."""
+    df = await exporter.to_polars(BARS, timestamp_format="iso")
+
+    with pytest.raises(ValueError, match=r'timestamp_format="unix"'):
+        validate_ohlcv(df, interval="1D")
+
+
+@pytest.mark.asyncio
+async def test_iso_frame_names_the_fix_in_the_conversion_error(exporter: DataExporter) -> None:
+    """Previously an opaque polars 'arithmetic on string and numeric' error."""
+    df = await exporter.to_polars(BARS, timestamp_format="iso")
+
+    with pytest.raises(ValueError, match=r'timestamp_format="unix"'):
+        convert_to_timezone(df, "Asia/Bangkok")
+
+
+@pytest.mark.asyncio
+async def test_scanner_input_ignores_timestamp_format(exporter: DataExporter) -> None:
+    """Scanner frames have no epoch column; export_timestamp stays an ISO string."""
+    from tvkit.api.scanner.models import StockData
+
+    rows = [StockData(name="AAPL", close=305.59, currency="USD")]
+
+    df = await exporter.to_polars(rows, timestamp_format="unix")  # type: ignore[arg-type]
+
+    assert df["export_timestamp"].dtype == pl.String

--- a/tests/test_scanner_row_drop.py
+++ b/tests/test_scanner_row_drop.py
@@ -1,0 +1,111 @@
+"""Tests for scanner row-drop reporting.
+
+``ScannerResponse.from_api_response`` skips rows it cannot parse so that one bad record
+cannot discard a whole response. It used to do so behind a bare ``except Exception:
+continue`` with no logging, which made ``len(data) < total_count`` ambiguous — it could
+mean either "the requested range was smaller" or "we threw your data away". Every drop is
+now counted on ``dropped_row_count`` and logged at WARNING.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from tvkit.api.scanner.models.scanner import ScannerResponse
+
+COLUMNS: list[str] = ["name", "close", "volume"]
+
+GOOD_ROW: dict[str, Any] = {"s": "NASDAQ:AAPL", "d": ["AAPL", 305.59, 38169263]}
+BAD_VALUE_ROW: dict[str, Any] = {"s": "NASDAQ:MSFT", "d": ["MSFT", "not-a-number", 22118613]}
+SHORT_ROW: dict[str, Any] = {"s": "NASDAQ:NVDA", "d": ["NVDA", 225.01]}
+
+
+def test_clean_response_reports_no_drops() -> None:
+    """A fully parseable payload leaves dropped_row_count at zero."""
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    parsed = ScannerResponse.from_api_response(response, COLUMNS)
+
+    assert len(parsed.data) == 1
+    assert parsed.dropped_row_count == 0
+
+
+def test_clean_response_logs_nothing() -> None:
+    """No warning is emitted when nothing is discarded."""
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    logger = logging.getLogger("tvkit.api.scanner.models.scanner")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append  # type: ignore[method-assign]
+    logger.addHandler(handler)
+    try:
+        ScannerResponse.from_api_response(response, COLUMNS)
+    finally:
+        logger.removeHandler(handler)
+
+    assert records == []
+
+
+def test_unparseable_rows_are_counted_not_hidden() -> None:
+    """Rows that fail validation are skipped but reported via dropped_row_count."""
+    response: dict[str, Any] = {
+        "data": [GOOD_ROW, BAD_VALUE_ROW, SHORT_ROW],
+        "totalCount": 3,
+    }
+
+    parsed = ScannerResponse.from_api_response(response, COLUMNS)
+
+    assert [s.name for s in parsed.data] == ["AAPL"]
+    assert parsed.dropped_row_count == 2, "silent data loss — the drop was not reported"
+    # The shortfall is now explainable: 3 rows in, 1 out, 2 accounted for.
+    assert len(parsed.data) + parsed.dropped_row_count == len(response["data"])
+
+
+def test_dropped_row_count_survives_serialization() -> None:
+    """The count is a real field, so a pipeline can assert on a dumped response."""
+    response: dict[str, Any] = {"data": [GOOD_ROW, SHORT_ROW], "totalCount": 2}
+
+    dumped = ScannerResponse.from_api_response(response, COLUMNS).model_dump()
+
+    assert dumped["dropped_row_count"] == 1
+
+
+def test_each_drop_is_logged_with_index_and_symbol(caplog: pytest.LogCaptureFixture) -> None:
+    """Each discarded row is logged at WARNING, naming the row and the symbol."""
+    response: dict[str, Any] = {
+        "data": [GOOD_ROW, BAD_VALUE_ROW, SHORT_ROW],
+        "totalCount": 3,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="tvkit.api.scanner.models.scanner"):
+        ScannerResponse.from_api_response(response, COLUMNS)
+
+    per_row = [r for r in caplog.records if getattr(r, "row_index", None) is not None]
+    assert len(per_row) == 2
+    assert {r.row_index for r in per_row} == {1, 2}  # type: ignore[attr-defined]
+    assert {r.symbol for r in per_row} == {"NASDAQ:MSFT", "NASDAQ:NVDA"}  # type: ignore[attr-defined]
+
+    summary = [r for r in caplog.records if getattr(r, "dropped_row_count", None) is not None]
+    assert len(summary) == 1
+    assert summary[0].dropped_row_count == 2  # type: ignore[attr-defined]
+
+
+def test_caller_errors_are_no_longer_swallowed() -> None:
+    """A bug in the call — not in the payload — must surface, not vanish.
+
+    The previous bare ``except Exception`` turned this into an empty response.
+    """
+    response: dict[str, Any] = {"data": [GOOD_ROW], "totalCount": 1}
+
+    with pytest.raises(TypeError):
+        ScannerResponse.from_api_response(response, None)  # type: ignore[arg-type]
+
+
+def test_missing_data_key_yields_an_empty_response() -> None:
+    """A payload with no 'data' key is empty, not a drop."""
+    parsed = ScannerResponse.from_api_response({"totalCount": 0}, COLUMNS)
+
+    assert parsed.data == []
+    assert parsed.dropped_row_count == 0

--- a/tests/test_timezone_utils.py
+++ b/tests/test_timezone_utils.py
@@ -303,25 +303,47 @@ class TestConvertToTimezone:
         result = convert_to_timezone(df, "UTC")
         assert isinstance(result["timestamp"].dtype, pl.Datetime)
 
-    def test_idempotency_data_corruption(self, df_seconds: pl.DataFrame) -> None:
+    def test_double_conversion_is_idempotent(self, df_seconds: pl.DataFrame) -> None:
         """
-        Calling convert_to_timezone on an already-converted Datetime column must
-        not silently produce a usable result.
+        Calling convert_to_timezone on an already-converted Datetime column is safe.
 
-        Polars behaviour varies by version:
-        - Older Polars: pl.from_epoch treats the datetime's internal microsecond
-          integer as a raw epoch, silently producing a corrupted value that overflows
-          Python's datetime range (OverflowError on value access).
-        - Newer Polars: pl.from_epoch explicitly rejects the operation and raises
-          InvalidOperationError during the conversion itself.
-
-        Both outcomes satisfy the API contract: convert_to_timezone expects an
-        integer/float epoch column. Never call it twice on the same column.
+        This used to be a footgun: pl.from_epoch was handed the datetime's internal
+        microsecond integer and either produced a corrupted value that overflowed
+        Python's datetime range, or raised InvalidOperationError, depending on the
+        Polars version. convert_to_timezone now detects an existing Datetime column
+        and only re-zones it, so a second call to the same timezone is a no-op.
         """
         converted = convert_to_timezone(df_seconds, "Asia/Bangkok")
-        with pytest.raises((OverflowError, pl.exceptions.InvalidOperationError)):
-            corrupted = convert_to_timezone(converted, "Asia/Bangkok")
-            _ = corrupted["timestamp"][0]
+        again = convert_to_timezone(converted, "Asia/Bangkok")
+
+        assert again["timestamp"].dtype == converted["timestamp"].dtype
+        assert again["timestamp"].to_list() == converted["timestamp"].to_list()
+
+    def test_reconversion_preserves_the_instant(self, df_seconds: pl.DataFrame) -> None:
+        """Re-zoning an already-converted column changes rendering, not the instant."""
+        bangkok = convert_to_timezone(df_seconds, "Asia/Bangkok")
+        new_york = convert_to_timezone(bangkok, "America/New_York")
+
+        assert new_york["timestamp"].dtype == pl.Datetime(
+            time_unit="us", time_zone="America/New_York"
+        )
+        assert new_york["timestamp"].to_list() == bangkok["timestamp"].to_list()
+
+    def test_naive_datetime_column_is_assumed_utc(self) -> None:
+        """A tz-naive Datetime column is treated as UTC, consistent with to_utc()."""
+        df = pl.DataFrame({"timestamp": [datetime(2026, 1, 1, 0, 0)]})
+
+        result = convert_to_timezone(df, "Asia/Bangkok")
+
+        assert result["timestamp"].dtype == pl.Datetime(time_unit="us", time_zone="Asia/Bangkok")
+        assert result["timestamp"][0].hour == 7
+
+    def test_string_column_raises_naming_the_fix(self) -> None:
+        """A String column raises ValueError pointing at to_polars(timestamp_format=...)."""
+        df = pl.DataFrame({"timestamp": ["2026-01-01T00:00:00+00:00"]})
+
+        with pytest.raises(ValueError, match=r'timestamp_format="unix"'):
+            convert_to_timezone(df, "Asia/Bangkok")
 
 
 # ── TestExchangeTimezone ──────────────────────────────────────────────────────

--- a/tvkit/api/scanner/models/scanner.py
+++ b/tvkit/api/scanner/models/scanner.py
@@ -5,9 +5,12 @@ This module provides Pydantic models for interacting with the TradingView
 scanner API, including request payloads and response parsing.
 """
 
+import logging
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class SortConfig(BaseModel):
@@ -314,6 +317,15 @@ class ScannerResponse(BaseModel):
     next_page_token: str | None = Field(
         default=None, description="Token for retrieving next page of results"
     )
+    dropped_row_count: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of rows present in the API payload that could not be parsed and were "
+            "discarded. Non-zero means data loss: len(data) is short by this many rows for a "
+            "reason unrelated to the requested range. Each drop is logged at WARNING."
+        ),
+    )
 
     @classmethod
     def from_api_response(
@@ -339,8 +351,9 @@ class ScannerResponse(BaseModel):
         """
         # Parse rows into StockData instances
         stocks: list[StockData] = []
+        dropped: int = 0
         if "data" in response_data:
-            for item in response_data["data"]:
+            for index, item in enumerate(response_data["data"]):
                 try:
                     # Handle new API format: {"s": "NASDAQ:AAPL", "d": [data_array]}
                     if isinstance(item, dict) and "d" in item:
@@ -360,15 +373,40 @@ class ScannerResponse(BaseModel):
 
                     stock = StockData.from_scanner_row(row_data, columns)
                     stocks.append(stock)
-                except Exception:
-                    # Log error but continue processing other rows
-                    # In production, you'd want proper logging here
+                except ValueError as exc:
+                    # Malformed upstream row: wrong length, or a value that fails validation.
+                    # pydantic's ValidationError subclasses ValueError, so both land here.
+                    # Skip the row so one bad record cannot discard a whole response, but never
+                    # skip it silently — see the dropped_row_count field.
+                    dropped += 1
+                    symbol_label: str = (
+                        str(item.get("s"))
+                        if isinstance(item, dict) and "s" in item
+                        else "<unknown>"
+                    )
+                    logger.warning(
+                        "Discarding unparseable scanner row %d (%s): %s",
+                        index,
+                        symbol_label,
+                        exc,
+                        extra={"row_index": index, "symbol": symbol_label},
+                    )
                     continue
+
+        if dropped:
+            logger.warning(
+                "Scanner response: discarded %d of %d row(s); len(data)=%d",
+                dropped,
+                len(response_data.get("data", [])),
+                len(stocks),
+                extra={"dropped_row_count": dropped},
+            )
 
         return cls(
             data=stocks,
             total_count=response_data.get("totalCount"),
             next_page_token=response_data.get("nextPageToken"),
+            dropped_row_count=dropped,
         )
 
 

--- a/tvkit/export/data_exporter.py
+++ b/tvkit/export/data_exporter.py
@@ -7,7 +7,7 @@ from tvkit APIs to various formats including Polars DataFrames, JSON, and CSV.
 
 import logging
 from pathlib import Path
-from typing import Any, cast, overload
+from typing import Any, Literal, cast, overload
 
 import polars as pl
 
@@ -319,18 +319,38 @@ class DataExporter:
         return rows
 
     @overload
-    async def to_polars(self, data: list[OHLCVBar], add_analysis: bool = False) -> Any: ...
+    async def to_polars(
+        self,
+        data: list[OHLCVBar],
+        add_analysis: bool = False,
+        *,
+        timestamp_format: Literal["iso", "unix", "datetime"] = "iso",
+    ) -> Any: ...
 
     @overload
-    async def to_polars(self, data: list[StockData], add_analysis: bool = False) -> Any: ...
+    async def to_polars(
+        self,
+        data: list[StockData],
+        add_analysis: bool = False,
+        *,
+        timestamp_format: Literal["iso", "unix", "datetime"] = "iso",
+    ) -> Any: ...
 
     @overload
-    async def to_polars(self, data: list[FundamentalsInput], add_analysis: bool = False) -> Any: ...
+    async def to_polars(
+        self,
+        data: list[FundamentalsInput],
+        add_analysis: bool = False,
+        *,
+        timestamp_format: Literal["iso", "unix", "datetime"] = "iso",
+    ) -> Any: ...
 
     async def to_polars(
         self,
         data: list[OHLCVBar] | list[StockData] | list[FundamentalsInput],
         add_analysis: bool = False,
+        *,
+        timestamp_format: Literal["iso", "unix", "datetime"] = "iso",
     ) -> Any:
         """
         Convenience method to export data directly to Polars DataFrame.
@@ -338,6 +358,19 @@ class DataExporter:
         Args:
             data: OHLCV bars or scanner data
             add_analysis: Whether to add financial analysis columns (OHLCV only)
+            timestamp_format: Dtype of the ``timestamp`` column for OHLCV input.
+
+                - ``"iso"`` (default) — ``String`` of ISO-8601 text, e.g.
+                  ``"2026-08-11T13:30:00+00:00"``. Readable, but **not accepted** by
+                  :func:`tvkit.validation.validate_ohlcv` or
+                  :func:`tvkit.time.convert_to_timezone`.
+                - ``"unix"`` — ``Float64`` epoch seconds. Accepted by both.
+                - ``"datetime"`` — tz-aware ``Datetime(time_unit="us", time_zone="UTC")``.
+                  Accepted by ``validate_ohlcv``; ``convert_to_timezone`` needs a numeric
+                  column, so use ``"unix"`` for timezone conversion.
+
+                Ignored for scanner and fundamentals input, whose timestamp-like columns
+                (``export_timestamp``, ``period_end``) are always ISO strings.
 
         Returns:
             Polars DataFrame with the exported data
@@ -346,9 +379,17 @@ class DataExporter:
             >>> exporter = DataExporter()
             >>> df = await exporter.to_polars(ohlcv_bars, add_analysis=True)
             >>> print(df.head())
+
+            Chaining into validation or timezone conversion needs a numeric column:
+
+            >>> df = await exporter.to_polars(ohlcv_bars, timestamp_format="unix")
+            >>> result = validate_ohlcv(df, interval="1D")
+            >>> df_local = convert_to_exchange_timezone(df, "NASDAQ")
         """
         config: ExportConfig = ExportConfig(
-            format=ExportFormat.POLARS, options={"add_analysis": add_analysis}
+            format=ExportFormat.POLARS,
+            timestamp_format=timestamp_format,
+            options={"add_analysis": add_analysis},
         )
 
         if data and isinstance(data[0], OHLCVBar):

--- a/tvkit/time/conversion.py
+++ b/tvkit/time/conversion.py
@@ -140,6 +140,11 @@ def convert_to_timezone(
     Without it, Polars treats the intermediate datetime column as naive and raises an error
     on ``convert_time_zone()``.
 
+    A column that is **already** a ``Datetime`` skips the epoch step and is only re-zoned
+    (a naive column is assumed UTC first). A non-numeric, non-temporal column — most often the
+    ``String`` produced by ``DataExporter.to_polars()`` under its default
+    ``timestamp_format="iso"`` — raises ``ValueError`` naming the fix.
+
     Args:
         df: Polars DataFrame containing the epoch numeric column.
         tz: IANA timezone string (e.g. ``"Asia/Bangkok"``, ``"America/New_York"``).
@@ -155,12 +160,34 @@ def convert_to_timezone(
     Raises:
         ZoneInfoNotFoundError: If ``tz`` is not a valid IANA timezone string.
         ColumnNotFoundError: If ``column`` is not present in ``df``.
+        ValueError: If ``column`` is not a numeric epoch column.
 
     Example:
         >>> from tvkit.time import convert_to_timezone
         >>> df_bkk = convert_to_timezone(df, "Asia/Bangkok")
         >>> df_ms  = convert_to_timezone(df_ms, "UTC", unit="ms")
     """
+    dtype = df[column].dtype if column in df.columns else None
+
+    if isinstance(dtype, pl.Datetime):
+        # Already temporal — there is no epoch to decode, only a zone to change. A naive
+        # column is assumed UTC, consistent with tvkit.time.to_utc().
+        expr = pl.col(column)
+        if dtype.time_zone is None:
+            expr = expr.dt.replace_time_zone("UTC")
+        return df.with_columns(expr.dt.convert_time_zone(tz).alias(column))
+
+    if dtype is not None and not dtype.is_numeric():
+        # Without this guard polars raises "arithmetic on string and numeric not allowed",
+        # which says nothing about which column or how to fix it. The overwhelmingly common
+        # cause is DataExporter.to_polars() defaulting to timestamp_format="iso".
+        raise ValueError(
+            f"Column {column!r} has dtype {dtype!r}, but an epoch conversion needs a numeric "
+            f"column. If this frame came from DataExporter.to_polars(), pass "
+            f'timestamp_format="unix" (Float64 epoch) or timestamp_format="datetime" '
+            f'(tz-aware Datetime) instead of the default "iso" (String).'
+        )
+
     return df.with_columns(
         pl.from_epoch(pl.col(column), time_unit=unit)
         .dt.replace_time_zone("UTC")

--- a/tvkit/validation/validator.py
+++ b/tvkit/validation/validator.py
@@ -74,8 +74,15 @@ def _require_ohlcv_schema(df: pl.DataFrame) -> None:
                 accepted_names = "Float64, Int64, Datetime, Date"
             else:
                 accepted_names = ", ".join(str(d) for d in accepted)
+            hint = ""
+            if col == "timestamp" and dtype == pl.String:
+                hint = (
+                    " If this frame came from DataExporter.to_polars(), pass "
+                    'timestamp_format="unix" (Float64) or timestamp_format="datetime" '
+                    'instead of the default "iso" (String).'
+                )
             raise ValueError(
-                f"Column {col!r} has unsupported dtype {dtype!r}. Accepted: {accepted_names}"
+                f"Column {col!r} has unsupported dtype {dtype!r}. Accepted: {accepted_names}.{hint}"
             )
 
 


### PR DESCRIPTION
## Summary

`to_polars()` hard-coded the default `ExportConfig`, whose `timestamp_format` is `"iso"` — a
`String` column. **Both consumers in the same library reject it**, so tvkit's own documented
fetch → export → validate/convert pipeline did not compose, and there was no way to ask
`to_polars()` for anything else.

This PR adds the missing knob, makes `"datetime"` frames chain too, and replaces two unhelpful
errors with ones that name the fix.

---

## Related issues

- Closes #42

---

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor (no behaviour change — code structure or performance improvement)
- [ ] Documentation (docs, docstrings, or examples only)
- [x] Tests (adding or updating tests only)
- [ ] Breaking change (changes existing behaviour or public API)
- [ ] Chore (CI, build system, dependencies, tooling)
- [ ] Other (describe below)

---

## Before

```python
df = await exporter.to_polars(bars)          # timestamp: String, not negotiable
convert_to_exchange_timezone(df, "NASDAQ")
# polars.exceptions.InvalidOperationError: arithmetic on string and numeric not allowed,
#   try an explicit cast first          ← names neither the column nor the fix
validate_ohlcv(df, interval="1D")
# ValueError: Column 'timestamp' has unsupported dtype String
```

`DataExporter(config=...)` and `to_polars(..., config=...)` both raise `TypeError` — the only escape
was `export_ohlcv_data()` with a hand-built `ExportConfig`.

## After

```python
df = await exporter.to_polars(bars, timestamp_format="unix")
validate_ohlcv(df, interval="1D")            # OK
convert_to_exchange_timezone(df, "NASDAQ")   # OK
```

Measured on 60 real AAPL daily bars:

| `timestamp_format` | dtype | `validate_ohlcv()` | `convert_to_timezone()` |
|---|---|---|---|
| `"iso"` **(default, unchanged)** | `String` | ✗ actionable `ValueError` | ✗ actionable `ValueError` |
| `"unix"` | `Float64` | ✓ | ✓ → `Datetime(us, America/New_York)` |
| `"datetime"` | `Datetime(us, UTC)` | ✓ | ✓ → `Datetime(us, America/New_York)` |

Omitting the argument produces a `String` column exactly as before.

---

## What changed

**1. `to_polars(*, timestamp_format=...)`** — keyword-only, so it cannot be passed positionally
where it would collide with `add_analysis`. Ignored for scanner and fundamentals input, whose
timestamp-like columns (`export_timestamp`, `period_end`) are always ISO strings.

**2. `convert_to_timezone()` handles an existing `Datetime` column** by only re-zoning it (a naive
column is assumed UTC, consistent with `to_utc()`) instead of feeding its internal microsecond
integer to `from_epoch`. This is what lets `timestamp_format="datetime"` chain — and it removes a
footgun the test suite had already documented: calling the function twice used to either corrupt the
value (older polars, `OverflowError` on access) or raise `InvalidOperationError`. It is now
idempotent, and re-zoning preserves the instant.

**3. Actionable errors.** Both consumers now name the column, its dtype, and the argument to pass:

```text
ValueError: Column 'timestamp' has dtype String, but an epoch conversion needs a numeric column.
  If this frame came from DataExporter.to_polars(), pass timestamp_format="unix" (Float64 epoch)
  or timestamp_format="datetime" (tz-aware Datetime) instead of the default "iso" (String).
```

---

## Quality gates

- [x] `uv run ruff check .` — lint passes
- [x] `uv run ruff format .` — formatting applied
- [x] `uv run mypy tvkit/` — type checking passes
- [x] `uv run python -m pytest tests/ -v` — 1120 passed, 2 skipped

`./scripts/check-docs.sh` is unchanged from `main` (same 4 pre-existing findings).

---

## Tests

- [x] Tests added or updated to cover this change
- [x] All existing tests still pass

`tests/test_export_timestamp_format.py` is new — 13 tests, all offline per `CONTRIBUTING.md`:
the default is unchanged; each value yields the documented dtype; the argument is keyword-only; a
typo is rejected; `"unix"` and `"datetime"` frames both validate **and** convert; the `"iso"` frame's
errors mention `timestamp_format="unix"`; scanner input ignores it.

Four tests added to `TestConvertToTimezone`. **One existing test was rewritten**:

> `test_idempotency_data_corruption` → `test_double_conversion_is_idempotent`
>
> Its name, docstring (*"Never call it twice on the same column"*) and assertion
> (`pytest.raises((OverflowError, InvalidOperationError))`) all pinned the corrupt-or-raise
> behaviour that change **2** deliberately removes. Renaming it rather than only flipping the
> assertion matters: a test called `..._data_corruption` that asserts the absence of corruption is
> worse than no test. Its replacement asserts idempotence, and a sibling asserts the instant
> survives a re-zone.

---

## Documentation

- [x] Docstrings updated for new or changed public functions
- [x] `docs/` updated (if behaviour or APIs changed)
- [x] `examples/` verified or updated (if applicable)

`docs/reference/export/exporter.md` gains the parameter in the signature and params table, plus a
compatibility matrix for the three values. `to_polars()`'s and `convert_to_timezone()`'s docstrings
document the dtypes and which consumer accepts what. `CHANGELOG.md` gains an `[Unreleased]` section.

---

## Breaking changes

- [ ] This PR introduces breaking changes

`timestamp_format` defaults to the previous behaviour, and the `Datetime` pass-through only affects
input that previously corrupted or raised. **One thing to know:** if you caught
`polars.exceptions.InvalidOperationError` around `convert_to_timezone()`, catch `ValueError`
instead.

---

## Additional notes

**Why not change the default to `"datetime"`?** It is the nicer end state (option 2 in #42) but it
silently changes the dtype under existing callers. This PR takes the additive route; flipping the
default is a separate, release-noted decision.

**Why not make the consumers accept an ISO `String`?** (option 3 in #42) Parsing ISO text inside
`convert_to_timezone` invites a subtle failure with mixed-offset strings, where lexical order stops
matching chronological order. Handling `Datetime` — unambiguous — while pointing `String` at the
right argument gets the composition without that hazard.

**Follow-up for #40.** That PR worked around this issue by rewriting 8 doc blocks to the verbose
`export_ohlcv_data(..., config=ExportConfig(timestamp_format="unix"))` form. Once both are merged
those can be simplified to `to_polars(bars, timestamp_format="unix")` — worth a small follow-up, in
`docs/guides/historical-data.md`, `docs/guides/data-validation.md`, `docs/concepts/timezones.md` and
`docs/faq.md`. I did not do it here because those blocks do not exist on `main` yet.

Related: #40, #43, #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
