### PR TITLE
docs: correct type names that do not exist in tvkit

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -64,8 +64,8 @@ framing, session handling) but exposes one-shot request/response methods rather 
 - `SegmentedFetchService` — splits large date ranges into segments, fetches sequentially, merges/deduplicates results (v0.5.0+)
 
 **Methods exposed**:
-- `get_historical_ohlcv()` — fetch N bars or a date range; returns `list[OHLCV]`
-- `get_ohlcv()` — stream live bars; returns `AsyncGenerator[OHLCV, None]`
+- `get_historical_ohlcv()` — fetch N bars or a date range; returns `list[OHLCVBar]`
+- `get_ohlcv()` — stream live bars; returns `AsyncGenerator[OHLCVBar, None]`
 - `get_quote_data()` — stream quote updates for a symbol
 - `get_latest_trade_info()` — monitor multiple symbols in one connection
 - `get_ohlcv_raw()` — access raw parsed messages for advanced use
@@ -82,7 +82,7 @@ framing, session handling) but exposes one-shot request/response methods rather 
 
 **Key components**:
 - `markets.py` — `Market` enum (69 markets), `MarketRegion` enum (5 regions), region grouping helpers
-- `models/scanner.py` — `ScannerRequest`, `ScannerFilter`, `ColumnSets`, `ScannerStock`
+- `models/scanner.py` — `ScannerRequest`, `ScannerResponse`, `ColumnSets`, `StockData`
 
 **Methods exposed**:
 - `scan_market(market, request)` — scan a single market; returns `ScannerResponse`

--- a/docs/concepts/streaming-vs-historical.md
+++ b/docs/concepts/streaming-vs-historical.md
@@ -24,7 +24,7 @@ tvkit provides two ways to access market data:
 
 | Property | `get_historical_ohlcv()` | `get_ohlcv()` |
 |----------|--------------------------|---------------|
-| Return type | `list[OHLCV]` — all bars at once | `AsyncGenerator[OHLCV, None]` — one bar per yield |
+| Return type | `list[OHLCVBar]` — all bars at once | `AsyncGenerator[OHLCVBar, None]` — one bar per yield |
 | Connection | Opens, fetches, closes | Stays open until you break or cancel |
 | Latency | One round-trip (~100–500ms) | Each bar delivered as it closes (<50ms) |
 | Data completeness | All requested bars guaranteed | Bars may be skipped if connection drops — backfill with `get_historical_ohlcv()` |

--- a/docs/concepts/symbols.md
+++ b/docs/concepts/symbols.md
@@ -25,7 +25,7 @@ The colon separator is required. TradingView's WebSocket API rejects symbols tha
 | US Equity | `NYSE:IBM` | — |
 | Crypto | `BINANCE:BTCUSDT` | Perpetual futures use exchange-specific notation |
 | Crypto | `COINBASE:ETHUSD` | — |
-| Forex | `FOREX:EURUSD` | Uses `FOREX` as the exchange prefix |
+| Forex | `FX_IDC:EURUSD` | `FOREX:` is not a TradingView exchange prefix |
 | Forex | `OANDA:XAUUSD` | Gold quoted in USD |
 | Index | `INDEX:SPX` | TradingView index identifiers |
 | Macro Indicator | `INDEX:NDFI` | Net Demand For Income |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -154,7 +154,7 @@ Polars DataFrames, CSV files, and JSON files. Parquet export is possible via Pol
 
 ### Can I export scanner results?
 
-Yes. Pass a `list[ScannerStock]` to `DataExporter`. See [Exporting Data](guides/exporting.md#scanner-results-export).
+Yes. Pass a `list[StockData]` to `DataExporter`. See [Exporting Data](guides/exporting.md#scanner-results-export).
 
 ---
 

--- a/docs/getting-started/first-script.md
+++ b/docs/getting-started/first-script.md
@@ -91,7 +91,7 @@ Bitcoin (BTCUSDT) — last 5 daily closes:
 | Element | What It Is |
 |---------|-----------|
 | `async with OHLCV()` | Context manager that opens and closes the WebSocket connection |
-| `await client.get_historical_ohlcv()` | Async call that returns a `list[OHLCV]` |
+| `await client.get_historical_ohlcv()` | Async call that returns a `list[OHLCVBar]` |
 | `exchange_symbol="NASDAQ:AAPL"` | Exchange prefix + ticker in colon format — see [Symbols](../concepts/symbols.md) |
 | `interval="1D"` | TradingView interval string — see [Intervals](../concepts/intervals.md) |
 | `bars_count=5` | Number of most recent bars to fetch |

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -32,8 +32,8 @@ OHLCV bars / scanner results
 
 `DataExporter` accepts:
 
-- `list[OHLCV]` — bars from `get_historical_ohlcv()` or a streaming buffer
-- `list[ScannerStock]` — results from `ScannerService.scan_market()`
+- `list[OHLCVBar]` — bars from `get_historical_ohlcv()` or a streaming buffer
+- `list[StockData]` — results from `ScannerService.scan_market()`
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #40, found by a post-merge audit. I swept every backticked CamelCase type name in the
user-facing docs against the actual package and found references that resolve to nothing.

#40 fixed each of these where it *first encountered* them but did not sweep the whole scope, so
copies survived in other files. That is the miss this PR closes.

---

## Related issues

- Follows up #40, #41

---

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (no behaviour change — code structure or performance improvement)
- [x] Documentation (docs, docstrings, or examples only)
- [ ] Tests (adding or updating tests only)
- [ ] Breaking change (changes existing behaviour or public API)
- [ ] Chore (CI, build system, dependencies, tooling)
- [ ] Other (describe below)

---

## What was wrong

| Wrong | Correct | Sites |
|---|---|---|
| `list[OHLCV]` | `list[OHLCVBar]` | 4 |
| `AsyncGenerator[OHLCV, None]` | `AsyncGenerator[OHLCVBar, None]` | 1 |
| `ScannerStock` | `StockData` | 3 |
| `ScannerFilter` | `ScannerResponse` | 1 |
| `FOREX:EURUSD` | `FX_IDC:EURUSD` | 1 |

**`list[OHLCV]`** is the interesting one. `OHLCV` *is* a real name — it's the client class — so it
resolves fine and no import check would flag it. But it is not what the method returns:

```python
>>> inspect.signature(OHLCV.get_historical_ohlcv).return_annotation
list[tvkit.api.chart.models.ohlcv.OHLCVBar]
>>> inspect.signature(OHLCV.get_ohlcv).return_annotation
collections.abc.AsyncGenerator[tvkit.api.chart.models.ohlcv.OHLCVBar, None]
```

**`ScannerFilter`** in `system-overview.md` is residue from #41 — that PR deleted the filter
sections from the scanner guide, but the architecture page still listed the type among the scanner
models.

**`FOREX:EURUSD`** was the most worth catching. It sat in the symbols concept table — the page a
reader consults *specifically* to learn symbol format — and its note claimed `FOREX` was the
exchange prefix. Re-confirmed against the live API before changing it:

```text
FOREX:EURUSD    s=error  errmsg=no_such_symbol  lp=None
FX_IDC:EURUSD   s=ok                            lp=1.15728
```

---

## Files

`docs/guides/exporting.md`, `docs/getting-started/first-script.md`,
`docs/concepts/streaming-vs-historical.md`, `docs/concepts/symbols.md`, `docs/faq.md`, and
`docs/architecture/system-overview.md`.

That last file was outside #40's agreed scope, but it carried the same one-word factual errors and
fixing it here was cheaper than tracking it separately.

---

## How I checked

Resolved every backticked identifier with two or more CamelCase humps against the full set of names
exported anywhere under `tvkit/`, across README, guides, getting-started, concepts and reference.
The hump count is what makes it work — earlier attempts keyed on prefixes like `Scanner` or
`Export` and drowned in ordinary prose.

**Result: `ScannerStock` was the only non-existent type name in the entire in-scope doc set.**
Everything else the sweep flagged was a Python builtin (`ValueError`, `TypeError`, `RuntimeError`,
`KeyError`) or a deliberate placeholder (`ClassName`, `SomePydanticModel`, `ParquetFormatter`).
`list[OHLCV]` and `FOREX:EURUSD` were found separately — neither is detectable by name resolution,
since both are real names used in the wrong place.

---

## Quality gates

- [x] `uv run ruff check .` — lint passes (no code changed)
- [x] `uv run mypy tvkit/` — type checking passes
- [x] `uv run python -m pytest tests/ -v` — 1130 passed, 2 skipped
- [x] `./scripts/check-docs.sh` — the 4 pre-existing findings, unchanged
- [x] Fence parity even in every changed file

---

## Documentation

- [x] Docstrings updated for new or changed public functions
- [x] `docs/` updated (if behaviour or APIs changed)
- [x] `examples/` verified or updated (if applicable)
- [x] New code examples include an Output block

No new code examples — this only corrects type names in prose and tables.

---

## Breaking changes

- [ ] This PR introduces breaking changes

---

## Additional notes

Worth noting for future doc work: none of these were catchable by running the examples, which is how
#40 validated everything else. All five live in prose and tables — `list[ScannerStock]` in a bullet,
a return type in a "Key Concepts" table, a symbol in a format table. Executable examples get checked
by execution; **prose type references need a name sweep**, and that is now a five-line script worth
keeping in mind for the next docs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
