### PR TITLE
fix(deps): declare pyyaml, which was imported but never a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.1] — 2026-08-26
+
+### Fixed
+
+- **`pyyaml` was imported but never declared as a dependency** (`pyproject.toml`, `tvkit.time`)  
+  `load_exchange_overrides()` does `import yaml`, but `pyyaml` appeared nowhere in
+  `[project.dependencies]`. It worked in development only by accident — `pre-commit` pulls `pyyaml`
+  in as a transitive **dev** dependency — so on a clean install of the published wheel the function
+  raised `ImportError`, despite being exported from `tvkit.time` and documented as public API with
+  no mention of an optional extra. Reproduced against the published 0.13.0:
+
+  ```
+  >>> from tvkit.time import load_exchange_overrides
+  >>> load_exchange_overrides("overrides.yaml")
+  ImportError: load_exchange_overrides() requires pyyaml...
+  ```
+
+  `pyyaml>=6.0.3` is now a declared runtime dependency. The lazy import and its `ImportError`
+  guard are kept as a safety net for a broken environment, with a message that now says so.
+
+  Note the import-time auto-load path (`TVKIT_EXCHANGE_OVERRIDES`) was **never** affected: it wraps
+  the call in `try/except` and degrades to a `WARNING`, so importing `tvkit.time` never failed.
+  Only direct calls to `load_exchange_overrides()` were broken.
+
+---
+
 ## [0.13.0] — 2026-08-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tvkit"
-version = "0.13.0"
+version = "0.13.1"
 description = "tvkit is a Python library that fetches real-time stock data from TradingView, including price, market cap, P/E ratio, ROE, and more for stocks from multiple countries. Easily access and analyze financial metrics for global markets."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -31,6 +31,7 @@ dependencies = [
     "rich>=14.1.0",
     "curl-cffi>=0.16.2",
     "browser-cookie3>=0.20.1",
+    "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]

--- a/tvkit/__init__.py
+++ b/tvkit/__init__.py
@@ -16,7 +16,7 @@ Quick Start:
     >>> data = asyncio.run(get_apple_data())
 """
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __author__ = "lumduan"
 __license__ = "MIT"
 

--- a/tvkit/time/exchange.py
+++ b/tvkit/time/exchange.py
@@ -219,7 +219,9 @@ def load_exchange_overrides(path: str | Path) -> None:
         import yaml  # type: ignore[import-untyped]
     except ImportError as exc:
         raise ImportError(
-            "load_exchange_overrides() requires pyyaml. Install it with: uv add pyyaml"
+            "load_exchange_overrides() requires pyyaml, which tvkit declares as a "
+            "runtime dependency — seeing this means the environment is incomplete. "
+            "Reinstall tvkit, or install it directly with: uv add pyyaml"
         ) from exc
 
     file_path = Path(path)

--- a/uv.lock
+++ b/uv.lock
@@ -2385,7 +2385,7 @@ wheels = [
 
 [[package]]
 name = "tvkit"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "browser-cookie3" },
@@ -2397,6 +2397,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "seaborn" },
     { name = "websockets" },
@@ -2443,6 +2444,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.4" },
     { name = "seaborn", specifier = ">=0.12.0" },


### PR DESCRIPTION
`tvkit/time/exchange.py:219` does `import yaml` inside `load_exchange_overrides()`, but `pyyaml` appeared nowhere in `[project.dependencies]`.

It worked in development **purely by accident**: `pre-commit` pulls `pyyaml` in as a transitive *dev* dependency, so it is always present in a contributor's environment and never in a user's. That is why the test suite has always passed while the published package was broken.

## Reproduced on the published 0.13.0

Runtime deps only, no dev extras:

```
>>> from tvkit.time import load_exchange_overrides
>>> load_exchange_overrides("overrides.yaml")
ImportError: load_exchange_overrides() requires pyyaml. Install it with: uv add pyyaml
```

`load_exchange_overrides` is exported from `tvkit.time.__all__` and documented in `docs/reference/time/index.md` as ordinary public API, with **no mention of an optional extra** — so the documented contract was broken on a clean install.

## Required dependency, not an optional extra

The code's design leans optional (lazy import, actionable `ImportError`), but nothing user-facing marks it that way — the reference docs list it alongside every other function. Making it required means the documented API works with no extra step. `pyyaml` is ~750 KB, trivial next to `pyarrow` and `matplotlib`, which are already required.

If you'd rather keep the base install lean, the alternative is `[project.optional-dependencies] yaml = ["pyyaml>=6.0.3"]` plus a docs note — say so and I'll switch it.

## Verified

Built the wheel and installed it with **no dev extras**:

```
Requires-Dist: pyyaml>=6.0.3          # present in wheel METADATA
load_exchange_overrides: OK
MYEXCH -> Asia/Bangkok
NASDAQ -> America/New_York
```

Plus the usual gate: ruff, `ruff format --check`, mypy, 1130 passed / 2 skipped.

## Scope note

The import-time auto-load path (`TVKIT_EXCHANGE_OVERRIDES`, `exchange.py:389`) was **never** affected — it wraps the call in `try/except` and degrades to a `WARNING`, so importing `tvkit.time` never failed. Only direct calls were broken. The lazy import and its guard are kept as a safety net, with the message reworded to say that reaching it now means the environment is incomplete.

Version bumped to **0.13.1** (PATCH — adding a dependency is additive).

## Separate issue found, not fixed here

`docs/reference/time/index.md:410` documents the signature as:

```python
def load_exchange_overrides(path: str | Path | None = None) -> None: ...
```

with `path` optional and an env-var fallback *inside* the function. The real signature is `load_exchange_overrides(path: str | Path)` — `path` is required and the env-var handling lives at module scope instead. Worth its own fix; flagging rather than bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LDQxcaGVCVJceN4VY1WTJ