### PR TITLE
docs(time): correct the load_exchange_overrides() reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`load_exchange_overrides()` reference docs described an API that does not exist**
+  (`docs/reference/time/index.md`)  
+  Four errors, the third of which caused silent data problems rather than an error:
+  - The signature was given as `load_exchange_overrides(path: str | Path | None = None)`. `path` is
+    required; there is no `None` default.
+  - It claimed that with `path=None` the function reads `TVKIT_EXCHANGE_OVERRIDES` and is otherwise
+    a no-op. The function never reads that variable — it is handled once at module scope when
+    `tvkit.time` is imported, and failures there are logged at `WARNING` and swallowed. Documented
+    correctly now, in its own section.
+  - **The YAML example omitted the required top-level `exchanges:` key.** A file in the documented
+    shape parses fine, loads **zero** overrides, and the affected exchanges silently fall back to
+    UTC — so following the docs produced wrong timezones with no error. (`tvkit_exchange_overrides.example.yaml`
+    in the repository root was always correct; only the reference page was wrong.)
+  - The `Raises` table listed `ZoneInfoNotFoundError`, which `register_exchange()` catches and
+    re-raises as `ValueError`. `ValueError` for a malformed file structure was missing entirely.
+
+  Documentation only — no library behaviour changed. Every claim on the page was re-verified by
+  executing it.
+
 ---
 
 ## [0.13.1] — 2026-08-26

--- a/docs/reference/time/index.md
+++ b/docs/reference/time/index.md
@@ -407,30 +407,48 @@ exchange_timezone("MYEX")  # "Asia/Kolkata"
 ## `load_exchange_overrides()`
 
 ```python
-def load_exchange_overrides(path: str | Path | None = None) -> None: ...
+def load_exchange_overrides(path: str | Path) -> None: ...
 ```
 
-Load exchange → IANA timezone overrides from a YAML file. If `path` is `None`, the function checks the `TVKIT_EXCHANGE_OVERRIDES` environment variable for a file path. If neither is provided, the function is a no-op.
+Load exchange → IANA timezone overrides from a YAML file. `path` is required — the function itself does not read any environment variable (see [Auto-loading at import time](#auto-loading-at-import-time) below).
 
 ### YAML Format
 
+Mappings live under a top-level `exchanges` key:
+
 ```yaml
-MYEX: Asia/Kolkata
-CUSTOM: America/Chicago
+exchanges:
+  MYEX: Asia/Kolkata
+  CUSTOM: America/Chicago
 ```
+
+The `exchanges` key is **required**. A file without it is not an error — it loads zero overrides, and the affected exchanges silently fall back to UTC. See `tvkit_exchange_overrides.example.yaml` in the repository root for a commented template.
+
+Exchange codes are case-insensitive (normalized to uppercase). User overrides take precedence over the built-in registry.
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `path` | `str \| Path \| None` | `None` | Path to a YAML file, or `None` to use the `TVKIT_EXCHANGE_OVERRIDES` environment variable |
+| `path` | `str \| Path` | *required* | Path to a YAML override file |
 
 ### Raises
 
 | Exception | When |
 |-----------|------|
-| `FileNotFoundError` | Path is provided but the file does not exist |
-| `ZoneInfoNotFoundError` | A timezone value in the YAML is not a valid IANA string |
+| `FileNotFoundError` | `path` does not exist |
+| `ValueError` | The file's top level is not a mapping, `exchanges` is not a mapping, or a timezone value is not a valid IANA string |
+| `ImportError` | `pyyaml` is unavailable. It is a declared runtime dependency since 0.13.1, so this indicates an incomplete environment |
+
+### Auto-loading at import time
+
+Setting `TVKIT_EXCHANGE_OVERRIDES` to a file path loads that file **once, when `tvkit.time` is first imported**:
+
+```bash
+export TVKIT_EXCHANGE_OVERRIDES=/path/to/overrides.yaml
+```
+
+This is handled at module scope, not by `load_exchange_overrides()`. Failures there are logged at `WARNING` and swallowed, so a missing or malformed file never prevents `tvkit.time` from importing — but it also means the overrides are silently absent. Call `load_exchange_overrides(path)` directly if you need failures to raise.
 
 ---
 

--- a/tvkit/time/exchange.py
+++ b/tvkit/time/exchange.py
@@ -191,8 +191,9 @@ def load_exchange_overrides(path: str | Path) -> None:
     """
     Load exchange timezone overrides from a YAML file.
 
-    Requires ``pyyaml`` (``uv add pyyaml``). YAML support is optional — the rest
-    of ``tvkit.time`` works without it.
+    ``pyyaml`` is a declared runtime dependency (since 0.13.1), so this works on a
+    normal install. The import below is kept lazy, and its ``ImportError`` guard
+    kept, only as a safety net for an incomplete environment.
 
     The YAML file must have an ``exchanges`` key mapping exchange codes to IANA
     timezone strings:

--- a/tvkit_exchange_overrides.example.yaml
+++ b/tvkit_exchange_overrides.example.yaml
@@ -18,7 +18,7 @@
 #   - Timezone strings must be valid IANA timezone identifiers.
 #     See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 #   - User overrides take precedence over the built-in registry.
-#   - Requires pyyaml: uv add pyyaml
+#   - pyyaml is installed automatically with tvkit (declared dependency since 0.13.1).
 
 exchanges:
   # Example: add a custom or new exchange


### PR DESCRIPTION
`docs/reference/time/index.md` documented an API that does not exist. Found while fixing the undeclared-`pyyaml` bug in #49.

**Four errors — the third produced silently wrong timezones rather than an error.**

| # | Documented | Reality |
|---|---|---|
| 1 | `load_exchange_overrides(path: str \| Path \| None = None)` | `path` is **required**; no `None` default |
| 2 | "If `path` is `None`, the function checks `TVKIT_EXCHANGE_OVERRIDES`… otherwise a no-op" | The function never reads that variable. It is handled **once at module scope** when `tvkit.time` is imported, and failures there are logged at `WARNING` and swallowed |
| 3 | YAML example with **no** `exchanges:` key | The key is **required** |
| 4 | Raises `ZoneInfoNotFoundError` | `register_exchange()` catches it and re-raises `ValueError`; `ValueError` for a malformed structure was missing entirely |

## Why #3 is the one that mattered

A file in the documented shape parses fine, loads **zero** overrides, and the affected exchanges silently fall back to UTC. No error, no warning that anything was wrong — just wrong timezones. Verified by running both:

```
# documented format
MYEX: Asia/Kolkata           ->  exchange_timezone("MYEX") == "UTC"

# actual format
exchanges:
  MYEX: Asia/Kolkata         ->  exchange_timezone("MYEX") == "Asia/Kolkata"
```

`tvkit_exchange_overrides.example.yaml` in the repo root was **always correct** — only the reference page was wrong, which is the worst combination, since the reference is what someone reads first.

## Verification

Every claim now on the page was re-verified by executing it, not by reading the source:

```
signature             : (path: str | pathlib.Path) -> None
MYEX                  : Asia/Kolkata
CUSTOM                : America/Chicago     (case-insensitivity claim)
missing-exchanges-key : no raise (loads 0)  (documented as a caveat)
bad-tz                : ValueError
top-level-list        : ValueError
missing-file          : FileNotFoundError
```

All four `Raises` rows now match observed behaviour.

## Also included

Two claims that **0.13.1 superseded**: the `exchange.py` docstring and the example file both still said `pyyaml` was optional / must be installed by hand. It is a declared runtime dependency now. The lazy import and its `ImportError` guard are kept as a safety net for an incomplete environment, and now say that explicitly rather than implying a normal setup step is missing.

## Scope

Documentation only — no library behaviour changed, so no version bump. Logged under `[Unreleased]`.

**Pre-existing, not touched:** the project's own `scripts/check_docs.py` reports 4 broken links, all in files this PR does not modify (`concepts/capabilities.md`, `concepts/timezones.md`, `faq.md`, `guides/historical-data.md`). Zero are in the edited file. Worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LDQxcaGVCVJceN4VY1WTJ