### PR TITLE
docs: fix two broken links, and the link checker that misreported two more

### DIFF
--- a/docs/concepts/timezones.md
+++ b/docs/concepts/timezones.md
@@ -1,6 +1,6 @@
 # Timezone Handling
 
-[Home](../index.md) > [Concepts](../concepts/index.md) > Timezone Handling
+[Home](../index.md) > Concepts > Timezone Handling
 
 tvkit uses a single, consistent rule for all timestamps:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -318,7 +318,7 @@ time storage and keeps your pipeline timezone-agnostic.
 
 ### I'm getting a `ConnectionClosed` error. What do I do?
 
-The WebSocket connection was dropped by the server. This can happen due to network instability, rate limiting, or the server closing idle connections. Implement retry logic with exponential backoff. See [Real-Time Streaming — Error Handling](guides/realtime-streaming.md#error-handling-and-retry).
+The WebSocket connection was dropped by the server. This can happen due to network instability, rate limiting, or the server closing idle connections. Implement retry logic with exponential backoff. See [Real-Time Streaming — Automatic Reconnection](guides/realtime-streaming.md#automatic-reconnection).
 
 ### tvkit raises `symbol_error`. What does that mean?
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -114,10 +114,16 @@ CODE_FENCE_RE = re.compile(r"^\s*```")
 
 
 def _slugify(text: str) -> str:
-    """Convert a Markdown heading to a GitHub-style anchor slug."""
+    """Convert a Markdown heading to a GitHub-style anchor slug.
+
+    Each whitespace character becomes its own hyphen, matching github-slugger.
+    Collapsing runs with ``\\s+`` is wrong: punctuation is stripped first, so a
+    heading like ``A — B`` leaves two spaces and GitHub renders ``a--b``. The
+    collapsing version reported valid ``--`` links as broken.
+    """
     slug = text.strip().lower()
     slug = re.sub(r"[^\w\s-]", "", slug)
-    slug = re.sub(r"\s+", "-", slug)
+    slug = re.sub(r"\s", "-", slug)
     return slug
 
 


### PR DESCRIPTION
`scripts/check_docs.py` reported 4 broken links. **Only 2 were real** — the other 2 were the checker being wrong about correct links.

## The 2 real breaks

**`docs/concepts/timezones.md:3`** → `../concepts/index.md`, which does not exist (`docs/concepts/` has no index). Every other concepts page writes the breadcrumb with **"Concepts" as plain text**; `timezones.md` was the only one linking it. Now matches the convention.

**`docs/faq.md:321`** → `guides/realtime-streaming.md#error-handling-and-retry`. That heading does not exist. The content the FAQ is pointing at — retry with exponential backoff — lives under `## Automatic Reconnection`, which is now the target, with the link text updated to match.

## The 2 false positives — a bug in the checker

```
docs/concepts/capabilities.md:17    -> ../limitations.md#tradingview-historical-depth-limitation--the-max_bars-window
docs/guides/historical-data.md:195  -> (same anchor)
```

**Both links were correct.** `_slugify()` collapsed whitespace runs via `re.sub(r"\s+", "-")`, but punctuation is stripped *first* — so the em dash in

```markdown
## TradingView Historical Depth Limitation — The `max_bars` Window
```

leaves **two** spaces, and github-slugger emits a **double** hyphen. The repo has no `mkdocs.yml` or `.readthedocs.yaml`, so these render on GitHub, where `--` is the correct anchor.

```
old (\s+ collapse): tradingview-historical-depth-limitation-the-max_bars-window
new (\s each)     : tradingview-historical-depth-limitation--the-max_bars-window   <- matches the link
```

Replacing `\s+` with `\s` matches github-slugger's behaviour.

This mattered beyond the noise: a checker that cries wolf on valid links trains people to ignore it, which is how the two *real* breaks survived alongside them.

## Verified

The count goes 4 reported → 2 (checker fixed, false positives gone, **no new failures introduced**) → 0 (real ones fixed):

```
All links OK  (71 files checked in docs/)
```

Full gate green: ruff, `ruff format --check`, mypy, 1135 passed / 2 skipped.

No library change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LDQxcaGVCVJceN4VY1WTJ